### PR TITLE
Add user namespace keep id completion

### DIFF
--- a/lsp/utils.go
+++ b/lsp/utils.go
@@ -131,3 +131,42 @@ func findLineStartWith(prefix string) ([]protocol.Location, error) {
 
 	return locations, nil
 }
+
+func findImageName(lines []string, lineNumber protocol.UInteger) string {
+	// First looking for `Image=value` value
+	// First looing for reverse, people usually define image first then parameters
+	imageName := ""
+	for i := lineNumber; i > 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, "Image=") {
+			tmp := strings.Split(line, "=")
+			if len(tmp) != 2 {
+				break
+			}
+			imageName = tmp[1]
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			// We've reached the start of section, try in other direction
+			break
+		}
+	}
+
+	// Check rest of the file for `Image=`
+	if imageName == "" {
+		for i := lineNumber; int(i) < len(lines); i++ {
+			line := strings.TrimSpace(lines[i])
+			if strings.HasPrefix(line, "Image=") {
+				tmp := strings.Split(line, "=")
+				if len(tmp) != 2 {
+					break
+				}
+				imageName = tmp[1]
+			}
+			if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+				// We've reached the start of another section
+				break
+			}
+		}
+	}
+	return imageName
+}


### PR DESCRIPTION
If user type `UserNS=keep-id:`, then `uid=xxx` and `gid=xxx` completions popup if something defined in the image. For example:

```
[
     {
          "Id": "1283872ef53ba6f365431208fc99f1a1b9c377c058fbc5ad799d58471174aae2",
          "Digest": "sha256:620c21188bee45c4145dbf1716117994eda3b9426d3d214de37a9468377a15d1",
          "RepoTags": [
               "docker.io/nginxinc/nginx-unprivileged:latest"
          ],
          "RepoDigests": [
               "docker.io/nginxinc/nginx-unprivileged@sha256:620c21188bee45c4145dbf1716117994eda3b9426d3d214de37a9468377a15d1",
               "docker.io/nginxinc/nginx-unprivileged@sha256:f9dfa9c20b2b0b7c5cc830374f22f23dee3f750b6c5291ca7e0330b5c88e6403"
          ],
          "Parent": "",
          "Comment": "debuerreotype 0.15",
          "Created": "2025-06-23T00:11:24.142738007Z",
          "Config": {
               "User": "101",  <=======
               "ExposedPorts": {
                    "8080/tcp": {}
               },
```