### PR TITLE
[syntax] QSR005 - Invalid value of AutoUpdate

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -6,6 +6,7 @@
 - [`QSR002` - Unfinished line](#qsr002---unfinished-line)
 - [`QSR003` - Invalid property](#qsr003---invalid-property)
 - [`QSR004` - Image name is not fully qualified](#qsr004---image-name-is-not-fully-qualified)
+- [`QSR005` - Invalid value of AutoUpdate](#qsr005---invalid-value-of-autoupdate)
 
 <!-- tocstop -->
 
@@ -81,3 +82,13 @@ Use fully qualified image name instead:
 Image=docker.io/library/debian:bookworm-slim
 
 ```
+
+## `QSR005` - Invalid value of AutoUpdate
+
+**Message**
+
+> Invalid value of AutoUpdate: _%value%_
+
+**Explanation**
+
+The `AutoUpdate` can only have `local` and `registry` values.

--- a/internal/syntax/qsr005.go
+++ b/internal/syntax/qsr005.go
@@ -1,0 +1,45 @@
+package syntax
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Verify value of AutoUpdate
+func qsr005(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	if !strings.HasSuffix(s.uri, ".container") && strings.HasSuffix(s.uri, ".kube") {
+		return diags
+	}
+
+	tmp := strings.Split(s.uri, ".")
+	section := utils.FirstCharacterToUpper(tmp[len(tmp)-1])
+
+	findings := utils.FindItems(
+		s.documentText,
+		section,
+		"AutoUpdate",
+	)
+
+	if len(findings) > 0 {
+		for _, f := range findings {
+			if f.Value != "registry" && f.Value != "local" {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: f.LineNumber, Character: 0},
+						End:   protocol.Position{Line: f.LineNumber, Character: f.Length},
+					},
+					Severity: &s.errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr005"),
+					Message:  fmt.Sprintf("Invalid value of AutoUpdate: %s", f.Value),
+				})
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr005_test.go
+++ b/internal/syntax/qsr005_test.go
@@ -1,0 +1,52 @@
+package syntax
+
+import (
+	"testing"
+)
+
+func TestQSR005_Valid(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nImage=cr.io/org/cont\nAutoUpdate=registry",
+		"test.container",
+	)
+
+	diags := qsr005(s)
+
+	if len(diags) != 0 {
+		t.Fatalf("Exptected 0, but got %d", len(diags))
+	}
+}
+
+func TestQSR005_ValidKube(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Kube]\nYAML=test.yaml\nAutoUpdate=local",
+		"test.kube",
+	)
+
+	diags := qsr005(s)
+
+	if len(diags) != 0 {
+		t.Fatalf("Exptected 0, but got %d", len(diags))
+	}
+}
+
+func TestQSR005_Invalid(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nImage=cr.io/org/cont\nAutoUpdate=foo",
+		"test.container",
+	)
+
+	diags := qsr005(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Exptected 1, but got %d", len(diags))
+	}
+
+	if diags[0].Message != "Invalid value of AutoUpdate: foo" {
+		t.Fatalf("Returned with wrong message tahn expected: %s", diags[0].Message)
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr005" {
+		t.Fatalf("Exptected 'quadlet-lsp.qsr005' source, got %s", *diags[0].Source)
+	}
+}

--- a/internal/utils/commander.go
+++ b/internal/utils/commander.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type Commander interface {
+	Run(name string, args ...string) ([]string, error)
+}
+
+type CommandExecutor struct{}
+
+// This method execute an OS command and return with its output
+func (c CommandExecutor) Run(name string, args ...string) ([]string, error) {
+	output := []string{}
+	cmd := exec.Command(name, args...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute podman: %w", err)
+	}
+
+	// Split output by newlines and filter out empty lines
+	for line := range strings.SplitSeq(out.String(), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			output = append(output, trimmed)
+		}
+	}
+	return output, nil
+}

--- a/internal/utils/general.go
+++ b/internal/utils/general.go
@@ -1,12 +1,10 @@
 package utils
 
 import (
-	"bytes"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
@@ -16,33 +14,10 @@ func ReturnAsStringPtr(s string) *string {
 	return &s
 }
 
-type Commander interface {
-	Run(name string, args ...string) ([]string, error)
-}
-
-type CommandExecutor struct{}
-
-// This method execute an OS command and return with its output
-func (c CommandExecutor) Run(name string, args ...string) ([]string, error) {
-	output := []string{}
-	cmd := exec.Command(name, args...)
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-
-	err := cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf("failed to execute podman: %w", err)
-	}
-
-	// Split output by newlines and filter out empty lines
-	for line := range strings.SplitSeq(out.String(), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed != "" {
-			output = append(output, trimmed)
-		}
-	}
-	return output, nil
+func FirstCharacterToUpper(s string) string {
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
 }
 
 // List quadlet files from the current work directory based on extenstion

--- a/internal/utils/general_test.go
+++ b/internal/utils/general_test.go
@@ -1,0 +1,42 @@
+package utils_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(content), 0644)
+	assert.NoError(t, err)
+	return path
+}
+
+func TestFirstCharacterToUpper(t *testing.T) {
+	v := utils.FirstCharacterToUpper("fooBar")
+
+	if v != "FooBar" {
+		t.Fatalf("Expected 'FooBar', instead got %s", v)
+	}
+}
+
+func TestListQuadletFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTestFile(t, tmpDir, "foo.pod", "placeholder")
+	createTestFile(t, tmpDir, "foo.network", "placeholder")
+	createTestFile(t, tmpDir, "bar.pod", "placeholder")
+
+	items, err := utils.ListQuadletFiles("*.pod")
+	assert.NoError(t, err)
+
+	if len(items) != 2 {
+		t.Fatalf("Expected 2 items, but got %d", len(items))
+	}
+}


### PR DESCRIPTION
## `QSR005` - Invalid value of AutoUpdate

**Message**

> Invalid value of AutoUpdate: _%value%_

**Explanation**

The `AutoUpdate` can only have `local` and `registry` values.
