### PR TITLE
[Syntax] QSR006 - Image file does not exists

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -7,6 +7,7 @@
 - [`QSR003` - Invalid property](#qsr003---invalid-property)
 - [`QSR004` - Image name is not fully qualified](#qsr004---image-name-is-not-fully-qualified)
 - [`QSR005` - Invalid value of AutoUpdate](#qsr005---invalid-value-of-autoupdate)
+- [`QSR006` - Image file does not exists](#qsr006---image-file-does-not-exists)
 
 <!-- tocstop -->
 
@@ -92,3 +93,14 @@ Image=docker.io/library/debian:bookworm-slim
 **Explanation**
 
 The `AutoUpdate` can only have `local` and `registry` values.
+
+## `QSR006` - Image file does not exists
+
+**Message**
+
+> Image file does not exists: _%name%_
+
+**Explanation**
+
+The specified `*.image` or `*.build` file does not exists that is used in the
+`Image=` line.

--- a/internal/syntax/qsr006.go
+++ b/internal/syntax/qsr006.go
@@ -1,6 +1,15 @@
 package syntax
 
 import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
@@ -9,7 +18,44 @@ import (
 func qsr006(s SyntaxChecker) []protocol.Diagnostic {
 	var diags []protocol.Diagnostic
 
-	// findings := utils.FindItems(s.documentText, "Container", "Image")
+	allowedFiles := []string{"container", "volume"}
+	tmp := strings.Split(s.uri, ".")
+	ext := tmp[len(tmp)-1]
+	if !slices.Contains(allowedFiles, ext) {
+		return diags
+	}
+
+	findings := utils.FindItems(
+		s.documentText,
+		utils.FirstCharacterToUpper(ext),
+		"Image",
+	)
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Printf("failed to detect cwd: %s", err.Error())
+		return diags
+	}
+
+	for _, finding := range findings {
+		if !strings.HasSuffix(finding.Value, ".image") && !strings.HasSuffix(finding.Value, ".build") {
+			continue
+		}
+
+		filePath := path.Join(cwd, finding.Value)
+		_, err := os.Stat(filePath)
+
+		if errors.Is(err, os.ErrNotExist) {
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Severity: &s.errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr006"),
+				Message:  fmt.Sprintf("Image file does not exists: %s", finding.Value),
+			})
+		}
+	}
 
 	return diags
 }

--- a/internal/syntax/qsr006_test.go
+++ b/internal/syntax/qsr006_test.go
@@ -1,0 +1,76 @@
+package syntax
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(content), 0644)
+	assert.NoError(t, err)
+	return path
+}
+
+func TestQSR006_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTestFile(t, tmpDir, "foo.image", "[Image]\nImage=docker.io/library/debian")
+
+	s := NewSyntaxChecker("[Container]\nImage=foo.image", "foo.container")
+	diags := qsr006(s)
+
+	if len(diags) != 0 {
+		t.Fatalf("Expected no diagnostics, but got %d", len(diags))
+	}
+}
+
+func TestQSR006_ValidVolume(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTestFile(t, tmpDir, "foo.image", "[Image]\nImage=docker.io/library/debian")
+
+	s := NewSyntaxChecker("[Volume]\nImage=foo.image", "foo.volume")
+	diags := qsr006(s)
+
+	if len(diags) != 0 {
+		t.Fatalf("Expected no diagnostics, but got %d", len(diags))
+	}
+}
+
+func TestQSR006_Skipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	s := NewSyntaxChecker("[Container]\nImage=library/debian", "foo.container")
+	diags := qsr006(s)
+
+	if len(diags) != 0 {
+		t.Fatalf("Expected no diagnostics, but got %d", len(diags))
+	}
+}
+
+func TestQSR006_Invalid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTestFile(t, tmpDir, "foo.image", "[Image]\nImage=docker.io/library/debian")
+
+	s := NewSyntaxChecker("[Container]\nImage=bar.image", "foo.container")
+	diags := qsr006(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Expected no diagnostics, but got %d", len(diags))
+	}
+
+	msg := "Image file does not exists: bar.image"
+	if diags[0].Message != msg {
+		t.Fatalf("Wrong error message expected: '%s', got: '%s'", msg, diags[0].Message)
+	}
+}


### PR DESCRIPTION
## `QSR006` - Image file does not exists

**Message**

> Image file does not exists: _%name%_

**Explanation**

The specified `*.image` or `*.build` file does not exists that is used in the
`Image=` line.
