### PR TITLE
[syntax] QSR007 - Invalid format of Environment variable specification

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -8,6 +8,7 @@
 - [`QSR004` - Image name is not fully qualified](#qsr004---image-name-is-not-fully-qualified)
 - [`QSR005` - Invalid value of AutoUpdate](#qsr005---invalid-value-of-autoupdate)
 - [`QSR006` - Image file does not exists](#qsr006---image-file-does-not-exists)
+- [`QSR007` - Invalid format of Environment variable](#qsr007---invalid-format-of-environment-variable)
 
 <!-- tocstop -->
 
@@ -104,3 +105,22 @@ The `AutoUpdate` can only have `local` and `registry` values.
 
 The specified `*.image` or `*.build` file does not exists that is used in the
 `Image=` line.
+
+## `QSR007` - Invalid format of Environment variable
+
+**Message**
+
+> Invalid format of Environment variable specification
+
+**Explanation**
+
+Environment variable must be specified as key-value pairs without having space
+before or after the `=` sign.
+
+Examples:
+
+```ini
+Environment=FOO=BAR   <-- Correct
+Environment=FOO       <-- Incorrect
+Environment=FOO = BAR <-- Incorrect
+```

--- a/internal/syntax/common.go
+++ b/internal/syntax/common.go
@@ -1,0 +1,22 @@
+package syntax
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+)
+
+// Function checking what is the extenstion in the URI
+// and return if it is on the allowed array list.
+// Return with the extension (with high capitalized first character)
+// if matches on list. If does not match return value is empty.
+func canFileBeApplied(uri string, allowed []string) string {
+	tmp := strings.Split(uri, ".")
+	ext := tmp[len(tmp)-1]
+	if slices.Contains(allowed, ext) {
+		return utils.FirstCharacterToUpper(ext)
+	}
+
+	return ""
+}

--- a/internal/syntax/common_test.go
+++ b/internal/syntax/common_test.go
@@ -1,0 +1,31 @@
+package syntax
+
+import "testing"
+
+func TestCanFileBeApplied_Valid(t *testing.T) {
+	list := []string{"container", "volume", "image"}
+
+	tmp := canFileBeApplied("file:///foo.container", list)
+	if tmp != "Container" {
+		t.Fatalf("expected 'Container', got '%s'", tmp)
+	}
+
+	tmp = canFileBeApplied("file:///foo.image", list)
+	if tmp != "Image" {
+		t.Fatalf("expected 'Image', got '%s'", tmp)
+	}
+
+	tmp = canFileBeApplied("file:///foo.volume", list)
+	if tmp != "Volume" {
+		t.Fatalf("expected 'Volume', got '%s'", tmp)
+	}
+}
+
+func TestCanFileBeApplied_Invalid(t *testing.T) {
+	list := []string{"container", "volume", "image"}
+
+	tmp := canFileBeApplied("file:///foo.network", list)
+	if tmp != "" {
+		t.Fatalf("expected '', got '%s'", tmp)
+	}
+}

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -31,6 +31,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr004,
 			qsr005,
 			qsr006,
+			qsr007,
 		},
 	}
 }

--- a/internal/syntax/qsr004.go
+++ b/internal/syntax/qsr004.go
@@ -1,7 +1,6 @@
 package syntax
 
 import (
-	"slices"
 	"strings"
 
 	"github.com/onlyati/quadlet-lsp/internal/utils"
@@ -13,17 +12,15 @@ func qsr004(s SyntaxChecker) []protocol.Diagnostic {
 	var diags []protocol.Diagnostic
 
 	allowedFiles := []string{"container", "image", "volume"}
-	tmp := strings.Split(s.uri, ".")
-	ext := tmp[len(tmp)-1]
-	if !slices.Contains(allowedFiles, ext) {
-		return diags
-	}
+	var findings []utils.QuadletLine
 
-	findings := utils.FindItems(
-		s.documentText,
-		utils.FirstCharacterToUpper(ext),
-		"Image",
-	)
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Image",
+		)
+	}
 
 	for _, finding := range findings {
 		if strings.HasSuffix(finding.Value, ".image") || strings.HasSuffix(finding.Value, ".build") {

--- a/internal/syntax/qsr005.go
+++ b/internal/syntax/qsr005.go
@@ -2,7 +2,6 @@ package syntax
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/onlyati/quadlet-lsp/internal/utils"
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -12,18 +11,16 @@ import (
 func qsr005(s SyntaxChecker) []protocol.Diagnostic {
 	var diags []protocol.Diagnostic
 
-	if !strings.HasSuffix(s.uri, ".container") && strings.HasSuffix(s.uri, ".kube") {
-		return diags
+	allowedFiles := []string{"container", "kube"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"AutoUpdate",
+		)
 	}
-
-	tmp := strings.Split(s.uri, ".")
-	section := utils.FirstCharacterToUpper(tmp[len(tmp)-1])
-
-	findings := utils.FindItems(
-		s.documentText,
-		section,
-		"AutoUpdate",
-	)
 
 	if len(findings) > 0 {
 		for _, f := range findings {

--- a/internal/syntax/qsr006.go
+++ b/internal/syntax/qsr006.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"slices"
 	"strings"
 
 	"github.com/onlyati/quadlet-lsp/internal/utils"
@@ -19,17 +18,16 @@ func qsr006(s SyntaxChecker) []protocol.Diagnostic {
 	var diags []protocol.Diagnostic
 
 	allowedFiles := []string{"container", "volume"}
-	tmp := strings.Split(s.uri, ".")
-	ext := tmp[len(tmp)-1]
-	if !slices.Contains(allowedFiles, ext) {
-		return diags
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Image",
+		)
 	}
 
-	findings := utils.FindItems(
-		s.documentText,
-		utils.FirstCharacterToUpper(ext),
-		"Image",
-	)
 	cwd, err := os.Getwd()
 	if err != nil {
 		log.Printf("failed to detect cwd: %s", err.Error())

--- a/internal/syntax/qsr007.go
+++ b/internal/syntax/qsr007.go
@@ -1,0 +1,59 @@
+package syntax
+
+import (
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Check syntax of Environment property
+func qsr007(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "build"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Environment",
+		)
+	}
+
+	for _, finding := range findings {
+		index := strings.Index(finding.Value, "=")
+
+		// Check if '=' is missing
+		cond1 := index == -1
+
+		// Cannot be space before or after the '=' sign
+		cond2 := false
+		if !cond1 {
+			cond2 = finding.Value[index-1] == ' '
+
+			if len(finding.Value)-1 > index {
+				cond2 = cond2 || finding.Value[index+1] == ' '
+			}
+		}
+
+		cond3 := index == len(finding.Value)-1
+
+		if cond1 || cond2 || cond3 {
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Message:  "Invalid format of Environment variable specification",
+				Severity: &s.errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr007"),
+			})
+			continue
+		}
+
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr007_test.go
+++ b/internal/syntax/qsr007_test.go
@@ -1,0 +1,76 @@
+package syntax
+
+import "testing"
+
+func TestQSR007_Valid(t *testing.T) {
+	variants := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nEnvironment=FOO1=BAR\nEnvironment=FOO2=BAR",
+			"test.container",
+		),
+		NewSyntaxChecker(
+			"[Build]\nEnvironment=FOO1=BAR\nEnvironment=FOO2=BAR",
+			"test.build",
+		),
+	}
+
+	for _, s := range variants {
+		diags := qsr007(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Exptected 0 diagnosis, but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR007_InvalidUnfinished(t *testing.T) {
+	variants := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nEnvironment=FOO",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nEnvironment=FOO=",
+			"test2.container",
+		),
+	}
+
+	for _, s := range variants {
+		diags := qsr007(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
+		}
+
+		if diags[0].Message != "Invalid format of Environment variable specification" {
+			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
+		}
+
+	}
+}
+
+func TestQSR007_InvalidSpaceFound(t *testing.T) {
+	variants := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nEnvironment=FOO = BAR",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nEnvironment=FOO =",
+			"test2.container",
+		),
+	}
+
+	for _, s := range variants {
+		diags := qsr007(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
+		}
+
+		if diags[0].Message != "Invalid format of Environment variable specification" {
+			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
+		}
+
+	}
+}


### PR DESCRIPTION
## `QSR007` - Invalid format of Environment variable

**Message**

> Invalid format of Environment variable specification

**Explanation**

Environment variable must be specified as key-value pairs without having space
before or after the `=` sign.

Examples:

```ini
Environment=FOO=BAR   <-- Correct
Environment=FOO       <-- Incorrect
Environment=FOO = BAR <-- Incorrect
```
