### PR TITLE
[syntax] QSR008 - Invalid format of Annotation specification

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -9,6 +9,7 @@
 - [`QSR005` - Invalid value of AutoUpdate](#qsr005---invalid-value-of-autoupdate)
 - [`QSR006` - Image file does not exists](#qsr006---image-file-does-not-exists)
 - [`QSR007` - Invalid format of Environment variable](#qsr007---invalid-format-of-environment-variable)
+- [`QSR008` - Invalid format of Annotation](#qsr008---invalid-format-of-annotation)
 
 <!-- tocstop -->
 
@@ -123,4 +124,23 @@ Examples:
 Environment=FOO=BAR   <-- Correct
 Environment=FOO       <-- Incorrect
 Environment=FOO = BAR <-- Incorrect
+```
+
+## `QSR008` - Invalid format of Annotation
+
+**Message**
+
+> Invalid format of Annotation specification
+
+**Explanation**
+
+Annotation must be specified as key-value pairs without having space before or
+after the `=` sign.
+
+Examples:
+
+```ini
+Annotation=FOO=BAR   <-- Correct
+Annotation=FOO       <-- Incorrect
+Annotation=FOO = BAR <-- Incorrect
 ```

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -32,6 +32,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr005,
 			qsr006,
 			qsr007,
+			qsr008,
 		},
 	}
 }

--- a/internal/syntax/qsr008.go
+++ b/internal/syntax/qsr008.go
@@ -1,0 +1,57 @@
+package syntax
+
+import (
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Verify Annotation property
+func qsr008(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "build"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Annotation",
+		)
+	}
+
+	for _, finding := range findings {
+		index := strings.Index(finding.Value, "=")
+
+		// Check if '=' is missing
+		cond1 := index == -1
+
+		// Cannot be space before or after the '=' sign
+		cond2 := false
+		if !cond1 {
+			cond2 = finding.Value[index-1] == ' '
+
+			if len(finding.Value)-1 > index {
+				cond2 = cond2 || finding.Value[index+1] == ' '
+			}
+		}
+
+		cond3 := index == len(finding.Value)-1
+
+		if cond1 || cond2 || cond3 {
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Message:  "Invalid format of Annotation specification",
+				Severity: &s.errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr008"),
+			})
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr008_test.go
+++ b/internal/syntax/qsr008_test.go
@@ -1,0 +1,76 @@
+package syntax
+
+import "testing"
+
+func TestQSR008_Valid(t *testing.T) {
+	variants := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nAnnotation=FOO1=BAR\nAnnotation=FOO2=BAR",
+			"test.container",
+		),
+		NewSyntaxChecker(
+			"[Build]\nAnnotation=FOO1=BAR\nAnnotation=FOO2=BAR",
+			"test.build",
+		),
+	}
+
+	for _, s := range variants {
+		diags := qsr008(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Exptected 0 diagnosis, but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR008_InvalidUnfinished(t *testing.T) {
+	variants := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nAnnotation=FOO",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nAnnotation=FOO=",
+			"test2.container",
+		),
+	}
+
+	for _, s := range variants {
+		diags := qsr008(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
+		}
+
+		if diags[0].Message != "Invalid format of Annotation specification" {
+			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
+		}
+
+	}
+}
+
+func TestQSR008_InvalidSpaceFound(t *testing.T) {
+	variants := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nAnnotation=FOO = BAR",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nAnnotation=FOO =",
+			"test2.container",
+		),
+	}
+
+	for _, s := range variants {
+		diags := qsr008(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
+		}
+
+		if diags[0].Message != "Invalid format of Annotation specification" {
+			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
+		}
+
+	}
+}


### PR DESCRIPTION
## `QSR008` - Invalid format of Annotation

**Message**

> Invalid format of Annotation specification

**Explanation**

Annotation must be specified as key-value pairs without having space before or
after the `=` sign.

Examples:

```ini
Annotation=FOO=BAR   <-- Correct
Annotation=FOO       <-- Incorrect
Annotation=FOO = BAR <-- Incorrect
```
