### PR TITLE
[syntax] QSR010 - Invalid port number is used at published port

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -11,6 +11,7 @@
 - [`QSR007` - Invalid format of Environment variable](#qsr007---invalid-format-of-environment-variable)
 - [`QSR008` - Invalid format of Annotation](#qsr008---invalid-format-of-annotation)
 - [`QSR009` - Invalid format of Label](#qsr009---invalid-format-of-label)
+- [`QSR010` - Incorrect format of PublishPort](#qsr010---incorrect-format-of-publishport)
 
 <!-- tocstop -->
 
@@ -164,3 +165,18 @@ Label=FOO=BAR   <-- Correct
 Label=FOO       <-- Incorrect
 Label=FOO = BAR <-- Incorrect
 ```
+
+## `QSR010` - Incorrect format of PublishPort
+
+**Message**
+
+> Incorrect format of PublishPort: _%reason%_
+
+**Explanation**
+
+Depends on the `reason` text:
+
+- `invalid format`: Line must have `PublishPort=xxx:xxx` or
+  `PublishPort=ip:xxx:xxx` format
+- `not a number`: Instead of port number, text is provided
+- `port must be between [0;65535]`: Invalid port number is used

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -6,13 +6,16 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
+var (
+	hintDiag = protocol.DiagnosticSeverityHint
+	infoDiag = protocol.DiagnosticSeverityInformation
+	warnDiag = protocol.DiagnosticSeverityWarning
+	errDiag  = protocol.DiagnosticSeverityError
+)
+
 type SyntaxChecker struct {
 	documentText string
 	uri          string
-	hintDiag     protocol.DiagnosticSeverity
-	infoDiag     protocol.DiagnosticSeverity
-	warnDiag     protocol.DiagnosticSeverity
-	errDiag      protocol.DiagnosticSeverity
 	checks       []func(SyntaxChecker) []protocol.Diagnostic
 }
 
@@ -20,10 +23,6 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 	return SyntaxChecker{
 		documentText: documentText,
 		uri:          uri,
-		hintDiag:     protocol.DiagnosticSeverityHint,
-		infoDiag:     protocol.DiagnosticSeverityInformation,
-		warnDiag:     protocol.DiagnosticSeverityWarning,
-		errDiag:      protocol.DiagnosticSeverityError,
 		checks: []func(SyntaxChecker) []protocol.Diagnostic{
 			qsr001,
 			qsr002,
@@ -34,6 +33,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr007,
 			qsr008,
 			qsr009,
+			qsr010,
 		},
 	}
 }

--- a/internal/syntax/qsr001.go
+++ b/internal/syntax/qsr001.go
@@ -32,7 +32,7 @@ func qsr001(s SyntaxChecker) []protocol.Diagnostic {
 			Start: protocol.Position{Line: 0, Character: 0},
 			End:   protocol.Position{Line: 0, Character: 0},
 		},
-		Severity: &s.errDiag,
+		Severity: &errDiag,
 		Message:  fmt.Sprintf("Missing any of these sections: %v", units),
 		Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr001"),
 	}

--- a/internal/syntax/qsr002.go
+++ b/internal/syntax/qsr002.go
@@ -22,7 +22,7 @@ func qsr002(s SyntaxChecker) []protocol.Diagnostic {
 					Start: protocol.Position{Line: lineNum, Character: 0},
 					End:   protocol.Position{Line: lineNum, Character: uint32(len(line))},
 				},
-				Severity: &s.errDiag,
+				Severity: &errDiag,
 				Message:  "Line is unfinished",
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr002"),
 			})

--- a/internal/syntax/qsr003.go
+++ b/internal/syntax/qsr003.go
@@ -61,7 +61,7 @@ func qsr003(s SyntaxChecker) []protocol.Diagnostic {
 					Start: protocol.Position{Line: lineNum - 1, Character: 0},
 					End:   protocol.Position{Line: lineNum - 1, Character: uint32(len(line) - 1)},
 				},
-				Severity: &s.errDiag,
+				Severity: &errDiag,
 				Message:  fmt.Sprintf("Invalid property is found: %s.%s", section, tmp[0]),
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr003"),
 			})

--- a/internal/syntax/qsr004.go
+++ b/internal/syntax/qsr004.go
@@ -32,7 +32,7 @@ func qsr004(s SyntaxChecker) []protocol.Diagnostic {
 					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
-				Severity: &s.warnDiag,
+				Severity: &warnDiag,
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr004"),
 				Message:  "Image name is not fully qualified",
 			})

--- a/internal/syntax/qsr005.go
+++ b/internal/syntax/qsr005.go
@@ -30,7 +30,7 @@ func qsr005(s SyntaxChecker) []protocol.Diagnostic {
 						Start: protocol.Position{Line: f.LineNumber, Character: 0},
 						End:   protocol.Position{Line: f.LineNumber, Character: f.Length},
 					},
-					Severity: &s.errDiag,
+					Severity: &errDiag,
 					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr005"),
 					Message:  fmt.Sprintf("Invalid value of AutoUpdate: %s", f.Value),
 				})

--- a/internal/syntax/qsr006.go
+++ b/internal/syntax/qsr006.go
@@ -48,7 +48,7 @@ func qsr006(s SyntaxChecker) []protocol.Diagnostic {
 					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
-				Severity: &s.errDiag,
+				Severity: &errDiag,
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr006"),
 				Message:  fmt.Sprintf("Image file does not exists: %s", finding.Value),
 			})

--- a/internal/syntax/qsr007.go
+++ b/internal/syntax/qsr007.go
@@ -47,7 +47,7 @@ func qsr007(s SyntaxChecker) []protocol.Diagnostic {
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
 				Message:  "Invalid format of Environment variable specification",
-				Severity: &s.errDiag,
+				Severity: &errDiag,
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr007"),
 			})
 			continue

--- a/internal/syntax/qsr008.go
+++ b/internal/syntax/qsr008.go
@@ -47,7 +47,7 @@ func qsr008(s SyntaxChecker) []protocol.Diagnostic {
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
 				Message:  "Invalid format of Annotation specification",
-				Severity: &s.errDiag,
+				Severity: &errDiag,
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr008"),
 			})
 		}

--- a/internal/syntax/qsr009.go
+++ b/internal/syntax/qsr009.go
@@ -47,7 +47,7 @@ func qsr009(s SyntaxChecker) []protocol.Diagnostic {
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
 				Message:  "Invalid format of Label specification",
-				Severity: &s.errDiag,
+				Severity: &errDiag,
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr009"),
 			})
 		}

--- a/internal/syntax/qsr010.go
+++ b/internal/syntax/qsr010.go
@@ -1,0 +1,115 @@
+package syntax
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Validate that the PublishPort line is correct
+func qsr010(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "pod", "kube"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"PublishPort",
+		)
+	}
+
+	for _, finding := range findings {
+		tmp := strings.Split(finding.Value, ":")
+
+		if len(tmp) == 2 {
+			// This is something like PublishPort=420:69
+			//                                   ^ this is the offset
+			if tmp[0] != "" {
+				tmpDiags := qsr010ValidatePortNumber(
+					tmp[0],
+					finding,
+					len(finding.Property)+1,
+				)
+				diags = append(diags, tmpDiags...)
+			}
+
+			tmpDiags := qsr010ValidatePortNumber(
+				tmp[1],
+				finding,
+				len(finding.Property)+1+len(tmp[0])+1,
+			)
+			diags = append(diags, tmpDiags...)
+
+			continue
+		}
+
+		if len(tmp) == 3 {
+			// This is something like PublishPort=127.0.0.1:420:69
+			//                                             ^ this is the offset
+			if tmp[1] != "" {
+				tmpDiags := qsr010ValidatePortNumber(
+					tmp[1],
+					finding,
+					len(finding.Property)+1+len(tmp[0])+1,
+				)
+				diags = append(diags, tmpDiags...)
+			}
+
+			tmpDiags := qsr010ValidatePortNumber(
+				tmp[2],
+				finding,
+				len(finding.Property)+1+len(tmp[1])+1+len(tmp[0])+1,
+			)
+			diags = append(diags, tmpDiags...)
+
+			continue
+		}
+
+		// If this is reached then line is probably incorrect format
+		diags = append(diags, protocol.Diagnostic{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+				End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+			},
+			Severity: &errDiag,
+			Message:  "Incorrect format of PublishPort: invalid format",
+			Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr010"),
+		})
+	}
+
+	return diags
+}
+
+func qsr010ValidatePortNumber(text string, finding utils.QuadletLine, offset int) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+	number, err := strconv.Atoi(text)
+	if err != nil {
+		diags = append(diags, protocol.Diagnostic{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: finding.LineNumber, Character: uint32(offset)},
+				End:   protocol.Position{Line: finding.LineNumber, Character: uint32(len(text) + offset)},
+			},
+			Severity: &errDiag,
+			Message:  "Incorrect format of PublishPort: not a number",
+			Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr010"),
+		})
+	}
+	if number < 0 || number > 65535 {
+		diags = append(diags, protocol.Diagnostic{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: finding.LineNumber, Character: uint32(offset)},
+				End:   protocol.Position{Line: finding.LineNumber, Character: uint32(len(text) + offset)},
+			},
+			Severity: &errDiag,
+			Message:  "Incorrect format of PublishPort: port must be between [0;65535]",
+			Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr010"),
+		})
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr010_test.go
+++ b/internal/syntax/qsr010_test.go
@@ -1,0 +1,155 @@
+package syntax
+
+import "testing"
+
+func TestQSR010_Valid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=10.0.0.1:420:69",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nPublishPort=10.0.0.1:420:69",
+			"test2.container",
+		),
+		NewSyntaxChecker(
+			"[Kube]\nPublishPort=10.0.0.1:420:69",
+			"test3.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=420:69",
+			"test4.container",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nPublishPort=420:69",
+			"test5.container",
+		),
+		NewSyntaxChecker(
+			"[Kube]\nPublishPort=420:69",
+			"test6.container",
+		),
+		NewSyntaxChecker(
+			"[Kube]\nPublishPort=:69",
+			"test7.container",
+		),
+		NewSyntaxChecker(
+			"[Kube]\nPublishPort=10.0.0.1::69",
+			"test8.container",
+		),
+	}
+
+	for _, s := range cases {
+		d := qsr010(s)
+
+		if len(d) != 0 {
+			t.Fatalf("Expected 0 diagnostics, but got %d at %s", len(d), s.uri)
+		}
+	}
+}
+
+func TestQSR010_InvalidFormat(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=10.0.0.1",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=420",
+			"test2.container",
+		),
+	}
+
+	for _, s := range cases {
+		d := qsr010(s)
+
+		if len(d) != 1 {
+			t.Fatalf("Expected 0 diagnostics, but got %d at %s", len(d), s.uri)
+		}
+
+		if *d[0].Source != "quadlet-lsp.qsr010" {
+			t.Fatalf("Wrong source, expected 'quadlet-lsp.qsr010', got '%s' at %s", *d[0].Source, s.uri)
+		}
+
+		if d[0].Message != "Incorrect format of PublishPort: invalid format" {
+			t.Fatalf("Unexpected message: '%s' at %s", d[0].Message, s.uri)
+		}
+	}
+}
+
+func TestQSR010_InvalidPortIsText(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=10.0.0.1:nice:420",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=10.0.0.1:69:ez",
+			"test2.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=nice:420",
+			"test3.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=69:ez",
+			"test4.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=69:",
+			"test4.container",
+		),
+	}
+
+	for _, s := range cases {
+		d := qsr010(s)
+
+		if len(d) != 1 {
+			t.Fatalf("Expected 0 diagnostics, but got %d at %s", len(d), s.uri)
+		}
+
+		if *d[0].Source != "quadlet-lsp.qsr010" {
+			t.Fatalf("Wrong source, expected 'quadlet-lsp.qsr010', got '%s' at %s", *d[0].Source, s.uri)
+		}
+
+		if d[0].Message != "Incorrect format of PublishPort: not a number" {
+			t.Fatalf("Unexpected message: '%s' at %s", d[0].Message, s.uri)
+		}
+	}
+}
+
+func TestQSR010_InvalidInvalidPortNumber(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=10.0.0.1:-69:420",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=10.0.0.1:69:80000",
+			"test2.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=-69:420",
+			"test3.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nPublishPort=69:80000",
+			"test4.container",
+		),
+	}
+
+	for _, s := range cases {
+		d := qsr010(s)
+
+		if len(d) != 1 {
+			t.Fatalf("Expected 0 diagnostics, but got %d at %s", len(d), s.uri)
+		}
+
+		if *d[0].Source != "quadlet-lsp.qsr010" {
+			t.Fatalf("Wrong source, expected 'quadlet-lsp.qsr010', got '%s' at %s", *d[0].Source, s.uri)
+		}
+
+		if d[0].Message != "Incorrect format of PublishPort: port must be between [0;65535]" {
+			t.Fatalf("Unexpected message: '%s' at %s", d[0].Message, s.uri)
+		}
+	}
+}


### PR DESCRIPTION
## `QSR010` - Incorrect format of PublishPort

**Message**

> Incorrect format of PublishPort: _%reason%_

**Explanation**

Depends on the `reason` text:

- `invalid format`: Line must have `PublishPort=xxx:xxx` or
  `PublishPort=ip:xxx:xxx` format
- `not a number`: Instead of port number, text is provided
- `port must be between [0;65535]`: Invalid port number is used
