### PR TITLE
[syntax] QSR011 - Port is not exposed in image

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -12,6 +12,7 @@
 - [`QSR008` - Invalid format of Annotation](#qsr008---invalid-format-of-annotation)
 - [`QSR009` - Invalid format of Label](#qsr009---invalid-format-of-label)
 - [`QSR010` - Incorrect format of PublishPort](#qsr010---incorrect-format-of-publishport)
+- [`QSR011` - Port is not exposed in image](#qsr011---port-is-not-exposed-in-image)
 
 <!-- tocstop -->
 
@@ -180,3 +181,15 @@ Depends on the `reason` text:
   `PublishPort=ip:xxx:xxx` format
 - `not a number`: Instead of port number, text is provided
 - `port must be between [0;65535]`: Invalid port number is used
+
+## `QSR011` - Port is not exposed in image
+
+**Message**
+
+> Port is not exposed in the image, exposed ports: %port_list%
+
+**Explanation**
+
+Port is used in container or pod that is not exposed by the image. In case of
+pod, first it discover which other container files are linked for the pod and
+analyze those images.

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -3,6 +3,7 @@ package syntax
 import (
 	"sync"
 
+	"github.com/onlyati/quadlet-lsp/internal/utils"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
@@ -17,6 +18,7 @@ type SyntaxChecker struct {
 	documentText string
 	uri          string
 	checks       []func(SyntaxChecker) []protocol.Diagnostic
+	commander    utils.Commander
 }
 
 func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
@@ -34,7 +36,9 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr008,
 			qsr009,
 			qsr010,
+			qsr011,
 		},
+		commander: utils.CommandExecutor{},
 	}
 }
 

--- a/internal/syntax/qsr011.go
+++ b/internal/syntax/qsr011.go
@@ -1,0 +1,51 @@
+package syntax
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// The exposed port is not present in the image
+func qsr011(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "pod"}
+	var findigs []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findigs = utils.FindItems(
+			s.documentText,
+			c,
+			"PublishPort",
+		)
+	}
+
+	if len(findigs) == 0 {
+		return diags
+	}
+
+	ports := utils.FindImageExposedPorts(s.commander, s.uri)
+
+	for _, finding := range findigs {
+		tmp := strings.Split(finding.Value, ":")
+		usedPort := tmp[len(tmp)-1]
+
+		if !slices.Contains(ports, usedPort) {
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Severity: &errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr011"),
+				Message:  fmt.Sprintf("Port is not exposed in the image, exposed ports: %v", ports),
+			})
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr011_test.go
+++ b/internal/syntax/qsr011_test.go
@@ -1,0 +1,206 @@
+package syntax
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCommanderQSR011 struct{}
+
+func (m mockCommanderQSR011) Run(name string, args ...string) ([]string, error) {
+	if args[2] == "mock1" {
+		return []string{
+			"[",
+			"	{",
+			"		 \"Config\": {",
+			"			\"ExposedPorts\": {",
+			"				\"8080/tcp\": {}",
+			"			}",
+			"		 }",
+			"	}",
+			"]",
+		}, nil
+	}
+	if args[2] == "mock2" {
+		return []string{
+			"[",
+			"	{",
+			"		 \"Config\": {",
+			"			\"ExposedPorts\": {",
+			"				\"69/tcp\": {}",
+			"			}",
+			"		 }",
+			"	}",
+			"]",
+		}, nil
+	}
+
+	return []string{}, nil
+}
+
+func createTempFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(content), 0644)
+	assert.NoError(t, err)
+	return path
+}
+
+func TestQSR011_ValidContainer(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test1.container",
+		"[Container]\nImage=mock1\nPublishPort=42069:8080",
+	)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nImage=mock1\nPublishPort=42069:8080",
+			"file://"+tmpDir+"/test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		s.commander = mockCommanderQSR011{}
+		diags := qsr011(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Exptected 0 diagnostics, but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR011_InvalidContainer(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test1.container",
+		"[Container]\nImage=mock1\nPublishPort=42069:8081",
+	)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nImage=mock1\nPublishPort=42069:8081",
+			"file://"+tmpDir+"/test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		s.commander = mockCommanderQSR011{}
+		diags := qsr011(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Exptected 1 diagnostics, but got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr011" {
+			t.Fatalf("Wrong source is used at %s", s.uri)
+		}
+
+		if diags[0].Message != "Port is not exposed in the image, exposed ports: [8080]" {
+			t.Fatalf("Unexptected message: '%s' at %s", diags[0].Message, s.uri)
+		}
+	}
+}
+
+func TestQSR011_ValidPod(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test.pod",
+		"[Pod]\nPublishPort=42069:8080",
+	)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test1.container",
+		"[Container]\nPod=test.pod\nImage=mock1",
+	)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test2.container",
+		"[Container]\nPod=test.pod\nImage=mock2",
+	)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Pod]\nPublishPort=42069:8080",
+			"file://"+tmpDir+"/test.pod",
+		),
+	}
+
+	for _, s := range cases {
+		s.commander = mockCommanderQSR011{}
+		diags := qsr011(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Exptected 0 diagnostics, but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR011_InvalidPod(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test.pod",
+		"[Pod]\nPublishPort=42069:5432",
+	)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test1.container",
+		"[Container]\nPod=test.pod\nImage=mock1",
+	)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test2.container",
+		"[Container]\nPod=test.pod\nImage=mock2",
+	)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Pod]\nPublishPort=42069:5432",
+			"file://"+tmpDir+"/test.pod",
+		),
+	}
+
+	for _, s := range cases {
+		s.commander = mockCommanderQSR011{}
+		diags := qsr011(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Exptected 1 diagnostics, but got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr011" {
+			t.Fatalf("Wrong source is used at %s", s.uri)
+		}
+
+		if diags[0].Message != "Port is not exposed in the image, exposed ports: [8080 69]" {
+			t.Fatalf("Unexptected message: '%s' at %s", diags[0].Message, s.uri)
+		}
+	}
+}

--- a/internal/utils/quadlet_scan.go
+++ b/internal/utils/quadlet_scan.go
@@ -1,6 +1,12 @@
 package utils
 
-import "strings"
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 type QuadletLine struct {
 	LineNumber uint32
@@ -47,4 +53,136 @@ func FindItems(text, section, property string) []QuadletLine {
 	}
 
 	return findings
+}
+
+func findImageInContainerUnit(f []byte) []string {
+	var images []string
+
+	lines := FindItems(
+		string(f),
+		"Container",
+		"Image",
+	)
+
+	for _, line := range lines {
+		if strings.HasSuffix(line.Value, ".image") {
+			f, err := os.ReadFile(line.Value)
+			if err != nil {
+				return images
+			}
+			lines := FindItems(
+				string(f),
+				"[Build]",
+				"Image",
+			)
+
+			for _, l := range lines {
+				img, _ := strings.CutSuffix(l.Value, ":")
+				images = append(images, img)
+			}
+			continue
+		}
+
+		if strings.HasSuffix(line.Value, ".build") {
+			// ignore for now
+			continue
+		}
+
+		// Here a pure image is defined like `Image=something.icr.io/org/name:tag`
+		img, _ := strings.CutSuffix(line.Value, ":")
+
+		images = append(images, img)
+	}
+	return images
+}
+
+// This function looking around the current working directory and looking
+// for references of the specified name
+func FindImageExposedPorts(c Commander, name string) []string {
+	var ports []string
+
+	name, _ = strings.CutPrefix(name, "file://")
+	var images []string
+
+	if strings.HasSuffix(name, ".container") {
+		f, err := os.ReadFile(name)
+		if err != nil {
+			log.Printf("failed to read file: %+v", err.Error())
+			return ports
+		}
+		images = findImageInContainerUnit(f)
+	}
+
+	if strings.HasSuffix(name, ".pod") {
+		tmp := strings.Split(name, string(os.PathSeparator))
+		podFileName := tmp[len(tmp)-1]
+
+		err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if info.IsDir() || !strings.HasSuffix(path, ".container") {
+				return nil
+			}
+
+			f, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			lines := FindItems(
+				string(f),
+				"Container",
+				"Pod",
+			)
+
+			if len(lines) > 0 {
+				if lines[0].Value == podFileName {
+					log.Printf("looking for in %s", lines[0].Value)
+					tmp := findImageInContainerUnit(f)
+					images = append(images, tmp...)
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			log.Printf("failed to walk to find container files: %+v", err.Error())
+			return ports
+		}
+	}
+
+	// We have the images, check the exposed ports
+	for _, img := range images {
+		output, err := c.Run(
+			"podman",
+			"image", "inspect", img,
+		)
+		if err != nil {
+			log.Printf("failed to inspect image: %+v", err.Error())
+			return ports
+		}
+
+		inspectJSON := strings.Join(output, "")
+		var data []map[string]any
+		json.Unmarshal([]byte(inspectJSON), &data)
+
+		config, ok := data[0]["Config"].(map[string]any)
+		if !ok {
+			return ports
+		}
+
+		exposedPorts, ok := config["ExposedPorts"].(map[string]any)
+		if !ok {
+			return ports
+		}
+
+		for port := range exposedPorts {
+			tmp := strings.Split(port, "/")
+			ports = append(ports, tmp[0])
+		}
+	}
+
+	return ports
 }


### PR DESCRIPTION
## `QSR011` - Port is not exposed in image

**Message**

> Port is not exposed in the image, exposed ports: %port_list%

**Explanation**

Port is used in container or pod that is not exposed by the image. In case of
pod, first it discover which other container files are linked for the pod and
analyze those images.
