### PR TITLE
[syntax] QSR013 - Volume file does not exists

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -13,6 +13,7 @@
 - [`QSR009` - Invalid format of Label](#qsr009---invalid-format-of-label)
 - [`QSR010` - Incorrect format of PublishPort](#qsr010---incorrect-format-of-publishport)
 - [`QSR011` - Port is not exposed in image](#qsr011---port-is-not-exposed-in-image)
+- [`QSR013` - Volume file does not exists](#qsr013---volume-file-does-not-exists)
 
 <!-- tocstop -->
 
@@ -193,3 +194,14 @@ Depends on the `reason` text:
 Port is used in container or pod that is not exposed by the image. In case of
 pod, first it discover which other container files are linked for the pod and
 analyze those images.
+
+## `QSR013` - Volume file does not exists
+
+**Message**
+
+> Volume file does not exists: _%volume_file%_
+
+**Explanation**
+
+The defined file, e.g.: `Volume=data.volume:/data`, does not exists in the
+current working directory.

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -37,6 +37,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr009,
 			qsr010,
 			qsr011,
+			qsr013,
 		},
 		commander: utils.CommandExecutor{},
 	}

--- a/internal/syntax/qsr013.go
+++ b/internal/syntax/qsr013.go
@@ -1,0 +1,60 @@
+package syntax
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Volume file does not exists
+func qsr013(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "pod", "build"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Volume",
+		)
+	}
+
+	for _, finding := range findings {
+		tmp := strings.Split(finding.Value, ":")
+		if len(tmp) == 0 {
+			continue
+		}
+
+		volName := tmp[0]
+		if strings.HasSuffix(volName, ".volume") {
+			_, err := os.Stat("./" + volName)
+
+			if errors.Is(err, os.ErrNotExist) {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: finding.LineNumber, Character: uint32(len(finding.Property) + 1)},
+						End:   protocol.Position{Line: finding.LineNumber, Character: uint32(len(finding.Property) + 1 + len(volName))},
+					},
+					Severity: &errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr013"),
+					Message:  fmt.Sprintf("Volume file does not exists: %s", volName),
+				})
+				continue
+			}
+
+			if err != nil {
+				log.Printf("failed to stat file: %s", err.Error())
+				continue
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr013_test.go
+++ b/internal/syntax/qsr013_test.go
@@ -1,0 +1,83 @@
+package syntax
+
+import (
+	"os"
+	"testing"
+)
+
+func TestQSR013_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"data1.volume",
+		"[Volume]",
+	)
+	createTempFile(
+		t,
+		tmpDir,
+		"data2.volume",
+		"[Volume]",
+	)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nVolume=data1.volume:/app:r\nVolume=data2.volume:/data/:rw",
+			"file://"+tmpDir+"/test1.container",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nVolume=data1.volume:/app:r\nVolume=data2.volume:/data/:rw",
+			"file://"+tmpDir+"/test2.pod",
+		),
+		NewSyntaxChecker(
+			"[Build]\nVolume=data1.volume:/app:r\nVolume=data2.volume:/data/:rw",
+			"file://"+tmpDir+"/test2.build",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr013(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR013_Invalid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nVolume=data1.volume:/app:r\nVolume=data2.volume:/data/:rw",
+			"file://"+tmpDir+"/test1.container",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nVolume=data1.volume:/app:r\nVolume=data2.volume:/data/:rw",
+			"file://"+tmpDir+"/test2.pod",
+		),
+		NewSyntaxChecker(
+			"[Build]\nVolume=data1.volume:/app:r\nVolume=data2.volume:/data/:rw",
+			"file://"+tmpDir+"/test2.build",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr013(s)
+
+		if len(diags) != 2 {
+			t.Fatalf("Expected 2 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr013" {
+			t.Fatalf("Wrong source found: %s at %s", *diags[0].Source, s.uri)
+		}
+
+		if diags[0].Message != "Volume file does not exists: data1.volume" {
+			t.Fatalf("Unexpected message: '%s' at %s", diags[0].Message, s.uri)
+		}
+	}
+}


### PR DESCRIPTION
## `QSR013` - Volume file does not exists

**Message**

> Volume file does not exists: _%volume_file%_

**Explanation**

The defined file, e.g.: `Volume=data.volume:/data`, does not exists in the
current working directory.
