### PR TITLE
[syntax] QSR014 - Network file does not exists

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -14,6 +14,7 @@
 - [`QSR010` - Incorrect format of PublishPort](#qsr010---incorrect-format-of-publishport)
 - [`QSR011` - Port is not exposed in image](#qsr011---port-is-not-exposed-in-image)
 - [`QSR013` - Volume file does not exists](#qsr013---volume-file-does-not-exists)
+- [`QSR014` - Network file does not exists](#qsr014---network-file-does-not-exists)
 
 <!-- tocstop -->
 
@@ -205,3 +206,14 @@ analyze those images.
 
 The defined file, e.g.: `Volume=data.volume:/data`, does not exists in the
 current working directory.
+
+## `QSR014` - Network file does not exists
+
+**Message**
+
+> Network file does not exists: _%network_file%_
+
+**Explanation**
+
+The defined file, e.g.: `Network=my.network`, does not exists in the current
+working directory.

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -38,6 +38,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr010,
 			qsr011,
 			qsr013,
+			qsr014,
 		},
 		commander: utils.CommandExecutor{},
 	}

--- a/internal/syntax/qsr014.go
+++ b/internal/syntax/qsr014.go
@@ -1,0 +1,55 @@
+package syntax
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Network file does not exist
+func qsr014(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "pod", "build", "kube"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Network",
+		)
+	}
+
+	for _, finding := range findings {
+		netName := finding.Value
+		if strings.HasSuffix(netName, ".network") {
+			_, err := os.Stat("./" + netName)
+
+			if errors.Is(err, os.ErrNotExist) {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: finding.LineNumber, Character: uint32(len(finding.Property) + 1)},
+						End:   protocol.Position{Line: finding.LineNumber, Character: uint32(len(finding.Property) + 1 + len(netName))},
+					},
+					Severity: &errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr014"),
+					Message:  fmt.Sprintf("Network file does not exists: %s", netName),
+				})
+				continue
+			}
+
+			if err != nil {
+				log.Printf("failed to stat file: %s", err.Error())
+				continue
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr014_test.go
+++ b/internal/syntax/qsr014_test.go
@@ -1,0 +1,91 @@
+package syntax
+
+import (
+	"os"
+	"testing"
+)
+
+func TestQSR014_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"net1.network",
+		"[Network]",
+	)
+	createTempFile(
+		t,
+		tmpDir,
+		"net2.network",
+		"[Network]",
+	)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test1.container",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test2.pod",
+		),
+		NewSyntaxChecker(
+			"[Build]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test2.build",
+		),
+		NewSyntaxChecker(
+			"[Kube]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test2.kube",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr014(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR014_Invalid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test1.container",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test2.pod",
+		),
+		NewSyntaxChecker(
+			"[Build]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test2.build",
+		),
+		NewSyntaxChecker(
+			"[Kube]\nNetwork=net1.network\nNetwork=net2.network",
+			"file://"+tmpDir+"/test2.kube",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr014(s)
+
+		if len(diags) != 2 {
+			t.Fatalf("Expected 2 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr014" {
+			t.Fatalf("Wrong source found: %s at %s", *diags[0].Source, s.uri)
+		}
+
+		if diags[0].Message != "Network file does not exists: net1.network" {
+			t.Fatalf("Unexpected message: '%s' at %s", diags[0].Message, s.uri)
+		}
+	}
+}


### PR DESCRIPTION
## `QSR014` - Network file does not exists

**Message**

> Network file does not exists: _%network_file%_

**Explanation**

The defined file, e.g.: `Network=my.network`, does not exists in the current
working directory.
