### PR TITLE
[syntax] QSR017 - Pod file does not exists

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -15,6 +15,7 @@
 - [`QSR011` - Port is not exposed in image](#qsr011---port-is-not-exposed-in-image)
 - [`QSR013` - Volume file does not exists](#qsr013---volume-file-does-not-exists)
 - [`QSR014` - Network file does not exists](#qsr014---network-file-does-not-exists)
+- [`QSR017` - Pod file does not exists](#qsr017---pod-file-does-not-exists)
 
 <!-- tocstop -->
 
@@ -217,3 +218,14 @@ current working directory.
 
 The defined file, e.g.: `Network=my.network`, does not exists in the current
 working directory.
+
+## `QSR017` - Pod file does not exists
+
+**Message**
+
+> Pod file does not exists: _%pod_file%_
+
+**Explanation**
+
+The defined file, e.g.: `Pod=my.pod`, does not exists in the current working
+directory.

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -39,6 +39,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr011,
 			qsr013,
 			qsr014,
+			qsr017,
 		},
 		commander: utils.CommandExecutor{},
 	}

--- a/internal/syntax/qsr017.go
+++ b/internal/syntax/qsr017.go
@@ -1,0 +1,55 @@
+package syntax
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Pod file does not exist
+func qsr017(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Pod",
+		)
+	}
+
+	for _, finding := range findings {
+		podName := finding.Value
+		if strings.HasSuffix(podName, ".pod") {
+			_, err := os.Stat("./" + podName)
+
+			if errors.Is(err, os.ErrNotExist) {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: finding.LineNumber, Character: uint32(len(finding.Property) + 1)},
+						End:   protocol.Position{Line: finding.LineNumber, Character: uint32(len(finding.Property) + 1 + len(podName))},
+					},
+					Severity: &errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr017"),
+					Message:  fmt.Sprintf("Pod file does not exists: %s", podName),
+				})
+				continue
+			}
+
+			if err != nil {
+				log.Printf("failed to stat file: %s", err.Error())
+				continue
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr017_test.go
+++ b/internal/syntax/qsr017_test.go
@@ -1,0 +1,61 @@
+package syntax
+
+import (
+	"os"
+	"testing"
+)
+
+func TestQSR017_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	createTempFile(
+		t,
+		tmpDir,
+		"test.pod",
+		"[Pod]",
+	)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPod=test.pod",
+			"file://"+tmpDir+"/test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr017(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR017_Invalid(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPod=test.pod",
+			"file://"+tmpDir+"/test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr017(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Expected 1 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr017" {
+			t.Fatalf("Wrong source found: %s at %s", *diags[0].Source, s.uri)
+		}
+
+		if diags[0].Message != "Pod file does not exists: test.pod" {
+			t.Fatalf("Unexpected message: '%s' at %s", diags[0].Message, s.uri)
+		}
+	}
+}


### PR DESCRIPTION
## `QSR017` - Pod file does not exists

**Message**

> Pod file does not exists: _%pod_file%_

**Explanation**

The defined file, e.g.: `Pod=my.pod`, does not exists in the current working
directory.
