### PR TITLE
[syntax] QSR018 and QSR019 implemented

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -16,6 +16,8 @@
 - [`QSR013` - Volume file does not exists](#qsr013---volume-file-does-not-exists)
 - [`QSR014` - Network file does not exists](#qsr014---network-file-does-not-exists)
 - [`QSR017` - Pod file does not exists](#qsr017---pod-file-does-not-exists)
+- [`QSR018` - Container cannot publish port with pod](#qsr018---container-cannot-publish-port-with-pod)
+- [`QSR019` - Container cannot have network with pod](#qsr019---container-cannot-have-network-with-pod)
 
 <!-- tocstop -->
 
@@ -229,3 +231,31 @@ working directory.
 
 The defined file, e.g.: `Pod=my.pod`, does not exists in the current working
 directory.
+
+## `QSR018` - Container cannot publish port with pod
+
+**Message**
+
+> Container cannot have PublishPort because belongs to a pod: _%pod_file%_
+
+**Explanation**
+
+A Pod in Podman shares a network namespace across all containers inside it. The
+pod is the unit that binds to the host network (e.g., 127.0.0.1:8080), not the
+individual containers.
+
+Each container in the pod uses 127.0.0.1 to reach other containers in the same
+pod.
+
+## `QSR019` - Container cannot have network with pod
+
+**Message**
+
+> Container cannot have Network because belongs to a pod: _%pod_file%_
+
+**Explanation**
+
+When you create a pod, it gets a single network namespace that all containers in
+the pod share. So: Containers in the same pod communicate over localhost
+(127.0.0.1). You assign the network (e.g. --network) when creating the pod, not
+per container.

--- a/internal/syntax/main.go
+++ b/internal/syntax/main.go
@@ -40,6 +40,8 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			qsr013,
 			qsr014,
 			qsr017,
+			qsr018,
+			qsr019,
 		},
 		commander: utils.CommandExecutor{},
 	}

--- a/internal/syntax/qsr018.go
+++ b/internal/syntax/qsr018.go
@@ -1,0 +1,44 @@
+package syntax
+
+import (
+	"fmt"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Container cannot have PublishPort if belongs to a pod
+func qsr018(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container"}
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		publishFindings := utils.FindItems(
+			s.documentText,
+			c,
+			"PublishPort",
+		)
+		podFindings := utils.FindItems(
+			s.documentText,
+			c,
+			"Pod",
+		)
+
+		if len(publishFindings) > 0 && len(podFindings) > 0 {
+			for _, p := range publishFindings {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: p.LineNumber, Character: 0},
+						End:   protocol.Position{Line: p.LineNumber, Character: p.Length},
+					},
+					Severity: &errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr018"),
+					Message:  fmt.Sprintf("Container cannot have PublishPort because belongs to a pod: %s", podFindings[0].Value),
+				})
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr018_test.go
+++ b/internal/syntax/qsr018_test.go
@@ -1,0 +1,45 @@
+package syntax
+
+import "testing"
+
+func TestQSR018_Valid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPod=test.pod",
+			"test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr018(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR018_Invalid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPod=test.pod\nPublishPort=420:69",
+			"test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr018(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr018" {
+			t.Fatalf("Wrong source found: %s at %s", *diags[0].Source, s.uri)
+		}
+
+		if diags[0].Message != "Container cannot have PublishPort because belongs to a pod: test.pod" {
+			t.Fatalf("Unexpected message: '%s' at %s", diags[0].Message, s.uri)
+		}
+	}
+}

--- a/internal/syntax/qsr019.go
+++ b/internal/syntax/qsr019.go
@@ -1,0 +1,44 @@
+package syntax
+
+import (
+	"fmt"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Container cannot have PublishPort if belongs to a pod
+func qsr019(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container"}
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		networkFindings := utils.FindItems(
+			s.documentText,
+			c,
+			"Network",
+		)
+		podFindings := utils.FindItems(
+			s.documentText,
+			c,
+			"Pod",
+		)
+
+		if len(networkFindings) > 0 && len(podFindings) > 0 {
+			for _, p := range networkFindings {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: p.LineNumber, Character: 0},
+						End:   protocol.Position{Line: p.LineNumber, Character: p.Length},
+					},
+					Severity: &errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr019"),
+					Message:  fmt.Sprintf("Container cannot have Network because belongs to a pod: %s", podFindings[0].Value),
+				})
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr019_test.go
+++ b/internal/syntax/qsr019_test.go
@@ -1,0 +1,45 @@
+package syntax
+
+import "testing"
+
+func TestQSR019_Valid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPod=test.pod",
+			"test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr019(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR019_Invalid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nPod=test.pod\nNetwork=my.network",
+			"test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr019(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr019" {
+			t.Fatalf("Wrong source found: %s at %s", *diags[0].Source, s.uri)
+		}
+
+		if diags[0].Message != "Container cannot have Network because belongs to a pod: test.pod" {
+			t.Fatalf("Unexpected message: '%s' at %s", diags[0].Message, s.uri)
+		}
+	}
+}


### PR DESCRIPTION
## `QSR018` - Container cannot publish port with pod

**Message**

> Container cannot have PublishPort because belongs to a pod: _%pod_file%_

**Explanation**

A Pod in Podman shares a network namespace across all containers inside it. The
pod is the unit that binds to the host network (e.g., 127.0.0.1:8080), not the
individual containers.

Each container in the pod uses 127.0.0.1 to reach other containers in the same
pod.

## `QSR019` - Container cannot have network with pod

**Message**

> Container cannot have Network because belongs to a pod: _%pod_file%_

**Explanation**

When you create a pod, it gets a single network namespace that all containers in
the pod share. So: Containers in the same pod communicate over localhost
(127.0.0.1). You assign the network (e.g. --network) when creating the pod, not
per container.
