### PR TITLE
[syntax] QSR012 - Invalid format of Secret specification

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -14,6 +14,7 @@
 - [`QSR009` - Invalid format of Label](#qsr009---invalid-format-of-label)
 - [`QSR010` - Incorrect format of PublishPort](#qsr010---incorrect-format-of-publishport)
 - [`QSR011` - Port is not exposed in image](#qsr011---port-is-not-exposed-in-image)
+- [`QSR012` - Invalid format of secret specification](#qsr012---invalid-format-of-secret-specification)
 - [`QSR013` - Volume file does not exists](#qsr013---volume-file-does-not-exists)
 - [`QSR014` - Network file does not exists](#qsr014---network-file-does-not-exists)
 - [`QSR017` - Pod file does not exists](#qsr017---pod-file-does-not-exists)
@@ -221,6 +222,22 @@ Depends on the `reason` text:
 Port is used in container or pod that is not exposed by the image. In case of
 pod, first it discover which other container files are linked for the pod and
 analyze those images.
+
+## `QSR012` - Invalid format of secret specification
+
+**Message**
+
+> Invalid format of secret specification: _%reason%_
+
+**Explanation**
+
+Depends on `reason` text:
+
+- `_%opt%_ has no value`: Invalid option
+- `'type' can be either 'mount' or 'env'`: Target is specified but with invalid
+  value
+- `'_%opt%_ only allowed if type=mount`: Using `uid`, `gid` or `mode` meanwhile
+  not `type=env` is set
 
 ## `QSR013` - Volume file does not exists
 

--- a/internal/syntax/qsr012.go
+++ b/internal/syntax/qsr012.go
@@ -1,0 +1,109 @@
+package syntax
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Invalid format of Secret specification
+func qsr012(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Secret",
+		)
+	}
+
+	for _, finding := range findings {
+		tmp := strings.Split(finding.Value, ",")
+
+		secretParms := map[string]string{}
+
+		for i, part := range tmp {
+			// Only interested in line like: Secret=my-secret,type=env,target=MYVAL
+			// Skip of only secret name is specified
+			if i == 0 {
+				continue
+			}
+
+			tmpPart := strings.Split(part, "=")
+			if len(tmpPart) == 1 {
+				// Option value did not specified
+				diags = append(diags, qsr012MakeDiag(
+					fmt.Sprintf(
+						"Invalid format of secret specification: '%s' has no value",
+						tmpPart[0],
+					),
+					finding,
+				))
+			} else {
+				// Check the option name
+				secretParms[tmpPart[0]] = tmpPart[1]
+			}
+		}
+
+		for k, v := range secretParms {
+			if k == "type" {
+				if v != "mount" && v != "env" {
+					diags = append(diags, qsr012MakeDiag(
+						"Invalid format of secret specification: 'type' can be either 'mount' or 'env'",
+						finding,
+					))
+				}
+				continue
+			}
+
+			if k == "target" {
+				// Nothing to check but it is a valid option
+				continue
+			}
+
+			if k == "uid" || k == "gid" || k == "mode" {
+				// They are invalid if the type is not mount
+				// If type is omitted then default is mount
+				// So they only invalid of type is "env"
+				if secretParms["type"] == "env" {
+					diags = append(diags, qsr012MakeDiag(
+						fmt.Sprintf(
+							"Invalid format of secret specification: '%s' only allowed if type=mount",
+							k,
+						),
+						finding,
+					))
+				}
+				continue
+			}
+
+			diags = append(diags, qsr012MakeDiag(
+				fmt.Sprintf(
+					"Invalid format of secret specification: '%s' is invalid option",
+					k,
+				),
+				finding,
+			))
+		}
+	}
+
+	return diags
+}
+
+func qsr012MakeDiag(text string, finding utils.QuadletLine) protocol.Diagnostic {
+	return protocol.Diagnostic{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+			End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+		},
+		Severity: &errDiag,
+		Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr012"),
+		Message:  text,
+	}
+}

--- a/internal/syntax/qsr012_test.go
+++ b/internal/syntax/qsr012_test.go
@@ -1,0 +1,129 @@
+package syntax
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQSR012_Valid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]Secret=my-secret",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]Secret=my-secret,target=/app/pw",
+			"test2.container",
+		),
+		NewSyntaxChecker(
+			"[Container]Secret=my-secret,type=mount,target=/app/pw",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]Secret=my-secret,uid=69,gid=420,mode=0400",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]Secret=my-secret,type=mount,uid=69,gid=420,mode=0400",
+			"test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr012(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR012_UnfinishedOption(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nSecret=my-secret,type\n",
+		"foo.container",
+	)
+
+	diags := qsr012(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Expected 1 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr012" {
+		t.Fatalf("Exptected source quadlet-lsp.qsr012, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid format of secret specification: 'type' has no value" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestQSR012_InvalidType(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nSecret=my-secret,type=foo\n",
+		"foo.container",
+	)
+
+	diags := qsr012(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Expected 1 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr012" {
+		t.Fatalf("Exptected source quadlet-lsp.qsr012, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid format of secret specification: 'type' can be either 'mount' or 'env'" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestQSR012_InvalidOption(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nSecret=my-secret,foo=bar\n",
+		"foo.container",
+	)
+
+	diags := qsr012(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Expected 1 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr012" {
+		t.Fatalf("Exptected source quadlet-lsp.qsr012, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid format of secret specification: 'foo' is invalid option" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestQSR012_InvalidWithEnv(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nSecret=my-secret,type=env,uid=69,gid=420,mode=0400\n",
+			"test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr012(s)
+
+		if len(diags) != 3 {
+			t.Fatalf("Expected 1 diagnostics, but got %d", len(diags))
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr012" {
+			t.Fatalf("Exptected source quadlet-lsp.qsr012, but got %s", *diags[0].Source)
+		}
+
+		checkMessageStart := strings.HasPrefix(diags[0].Message, "Invalid format of secret specification: ")
+		checkMessageSuffix := strings.HasSuffix(diags[0].Message, "' only allowed if type=mount")
+		if !checkMessageStart || !checkMessageSuffix {
+			t.Fatalf("Unexpected message: %s", diags[0].Message)
+		}
+	}
+}

--- a/internal/syntax/syntax.go
+++ b/internal/syntax/syntax.go
@@ -44,6 +44,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			{"qsr009", qsr009},
 			{"qsr010", qsr010},
 			{"qsr011", qsr011},
+			{"qsr012", qsr012},
 			{"qsr013", qsr013},
 			{"qsr014", qsr014},
 			{"qsr017", qsr017},

--- a/internal/utils/quadlet_scan.go
+++ b/internal/utils/quadlet_scan.go
@@ -13,6 +13,7 @@ type QuadletLine struct {
 	Length     uint32
 	Property   string
 	Value      string
+	RawLine    string
 }
 
 // This function scanning the passed text and
@@ -23,8 +24,8 @@ func FindItems(text, section, property string) []QuadletLine {
 	section = "[" + section + "]"
 	inSection := false
 
-	for i, line := range strings.Split(text, "\n") {
-		line = strings.TrimSpace(line)
+	for i, rawLine := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(rawLine)
 
 		if inSection && strings.Contains(line, "=") {
 			tmp := strings.SplitN(line, "=", 2)
@@ -35,6 +36,7 @@ func FindItems(text, section, property string) []QuadletLine {
 						Length:     uint32(len(line)),
 						Property:   tmp[0],
 						Value:      tmp[1],
+						RawLine:    rawLine,
 					})
 				}
 			}


### PR DESCRIPTION
## `QSR012` - Invalid format of secret specification

**Message**

> Invalid format of secret specification: _%reason%_

**Explanation**

Depends on `reason` text:

- `_%opt%_ has no value`: Invalid option
- `'type' can be either 'mount' or 'env'`: Target is specified but with invalid
  value
- `'_%opt%_ only allowed if type=mount`: Using `uid`, `gid` or `mode` meanwhile
  not `type=env` is set

