### PR TITLE
[syntax] QSR015 - Invalid format of Volume specification

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -17,6 +17,7 @@
 - [`QSR012` - Invalid format of secret specification](#qsr012---invalid-format-of-secret-specification)
 - [`QSR013` - Volume file does not exists](#qsr013---volume-file-does-not-exists)
 - [`QSR014` - Network file does not exists](#qsr014---network-file-does-not-exists)
+- [`QSR015` - Invalid format of Volume specification](#qsr015---invalid-format-of-volume-specification)
 - [`QSR017` - Pod file does not exists](#qsr017---pod-file-does-not-exists)
 - [`QSR018` - Container cannot publish port with pod](#qsr018---container-cannot-publish-port-with-pod)
 - [`QSR019` - Container cannot have network with pod](#qsr019---container-cannot-have-network-with-pod)
@@ -233,10 +234,10 @@ analyze those images.
 
 Depends on `reason` text:
 
-- `_%opt%_ has no value`: Invalid option
+- `%opt% has no value`: Invalid option
 - `'type' can be either 'mount' or 'env'`: Target is specified but with invalid
   value
-- `'_%opt%_ only allowed if type=mount`: Using `uid`, `gid` or `mode` meanwhile
+- `'%opt%' only allowed if type=mount`: Using `uid`, `gid` or `mode` meanwhile
   not `type=env` is set
 
 ## `QSR013` - Volume file does not exists
@@ -260,6 +261,19 @@ current working directory.
 
 The defined file, e.g.: `Network=my.network`, does not exists in the current
 working directory.
+
+## `QSR015` - Invalid format of Volume specification
+
+**Message**
+
+> Invalid format of Volume specification: _%reason%_
+
+**Explanation**
+
+Depends on the `reason`:
+
+- `container directory is not absolute`: Container directory must be absolute
+- `'%flag%' is unkown`: Not existing flag is used
 
 ## `QSR017` - Pod file does not exists
 

--- a/internal/syntax/qsr015.go
+++ b/internal/syntax/qsr015.go
@@ -1,0 +1,81 @@
+package syntax
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Invalid format of Volume specification
+func qsr015(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "pod", "build"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"Volume",
+		)
+	}
+
+	validFlags := []string{
+		"rw",
+		"ro",
+		"z",
+		"Z",
+		"O",
+		"U",
+		"copy", "nocopy",
+		"dev", "nodev",
+		"exec", "noexec",
+		"suid", "nosuid",
+		"bind", "rbind",
+		"shared", "shared",
+		"slave", "rslave",
+		"private", "rprivate",
+		"unbindable", "runbindable",
+	}
+
+	for _, finding := range findings {
+		tmp := strings.Split(finding.Value, ":")
+
+		if len(tmp) >= 2 {
+			if !strings.HasPrefix(tmp[1], "/") {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+						End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+					},
+					Severity: &errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr015"),
+					Message:  "Invalid format of Volume specification: container directory is not absolute",
+				})
+			}
+		}
+
+		if len(tmp) == 3 {
+			// Verify flags
+			for f := range strings.SplitSeq(tmp[2], ",") {
+				if !slices.Contains(validFlags, f) {
+					diags = append(diags, protocol.Diagnostic{
+						Range: protocol.Range{
+							Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+							End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+						},
+						Severity: &errDiag,
+						Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr015"),
+						Message:  fmt.Sprintf("Invalid format of Volume specification: '%s' flag is unknown", f),
+					})
+				}
+			}
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr015_test.go
+++ b/internal/syntax/qsr015_test.go
@@ -1,0 +1,72 @@
+package syntax
+
+import (
+	"testing"
+)
+
+func TestQSR015_Valid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nVolume=foo.volume:/app",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nVolume=foo.volume:/app:ro",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nVolume=foo.volume:/app:ro,Z",
+			"test1.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr015(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR015_InvalidContainerDirectory(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nVolume=foo.volume:data/config",
+		"test1.container",
+	)
+
+	diags := qsr015(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Expected 1 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr015" {
+		t.Fatalf("Exptected quadlet-lsp.qsr015 source, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid format of Volume specification: container directory is not absolute" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestQSR016_UnkownFlag(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nVolume=foo.volume:/app/data/config:rw,Z,foo,nocopy",
+		"test1.container",
+	)
+
+	diags := qsr015(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Expected 1 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr015" {
+		t.Fatalf("Exptected quadlet-lsp.qsr015 source, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid format of Volume specification: 'foo' flag is unknown" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}

--- a/internal/syntax/syntax.go
+++ b/internal/syntax/syntax.go
@@ -47,6 +47,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			{"qsr012", qsr012},
 			{"qsr013", qsr013},
 			{"qsr014", qsr014},
+			{"qsr015", qsr015},
 			{"qsr017", qsr017},
 			{"qsr018", qsr018},
 			{"qsr019", qsr019},


### PR DESCRIPTION
## `QSR015` - Invalid format of Volume specification

**Message**

> Invalid format of Volume specification: _%reason%_

**Explanation**

Depends on the `reason`:

- `container directory is not absolute`: Container directory must be absolute
- `'%flag%' is unkown`: Not existing flag is used

