### PR TITLE
[syntax] QSR016 - Invalid value of UserNS specification

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -18,6 +18,7 @@
 - [`QSR013` - Volume file does not exists](#qsr013---volume-file-does-not-exists)
 - [`QSR014` - Network file does not exists](#qsr014---network-file-does-not-exists)
 - [`QSR015` - Invalid format of Volume specification](#qsr015---invalid-format-of-volume-specification)
+- [`QSR016` - Invalid value of UserNS specification](#qsr016---invalid-value-of-userns-specification)
 - [`QSR017` - Pod file does not exists](#qsr017---pod-file-does-not-exists)
 - [`QSR018` - Container cannot publish port with pod](#qsr018---container-cannot-publish-port-with-pod)
 - [`QSR019` - Container cannot have network with pod](#qsr019---container-cannot-have-network-with-pod)
@@ -274,6 +275,22 @@ Depends on the `reason`:
 
 - `container directory is not absolute`: Container directory must be absolute
 - `'%flag%' is unkown`: Not existing flag is used
+
+## `QSR016` - Invalid value of UserNS specification
+
+**Message**
+
+> Invalid value of UserNS: allowed values: _%reason%_
+
+**Explanation**
+
+Depends on the values of `reason`:
+
+- `%opt% has no paramerets`: Only `keep-id` can have further parameters
+- `[uid gid] allowed but found %opt%`: Uses `keep-id` with other parameters than
+  `uid` or `gid`
+- `allowed values: [auto host keep-id nomap] but found %opt%`: Using invalid
+  value of `UserNS`
 
 ## `QSR017` - Pod file does not exists
 

--- a/internal/completion/property_userns.go
+++ b/internal/completion/property_userns.go
@@ -42,6 +42,7 @@ func propertyListUserIDs(s Completion) []protocol.CompletionItem {
 		return nil
 	}
 	inspectJSON := strings.Join(output, "")
+	log.Println(inspectJSON)
 	var data []map[string]any
 	json.Unmarshal([]byte(inspectJSON), &data)
 

--- a/internal/syntax/qsr016.go
+++ b/internal/syntax/qsr016.go
@@ -1,0 +1,85 @@
+package syntax
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Invalid value of UserNS specification
+func qsr016(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	allowedFiles := []string{"container", "pod", "kube"}
+	var findings []utils.QuadletLine
+
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			"UserNS",
+		)
+	}
+
+	allowdUserNs := []string{
+		"auto",
+		"host",
+		"keep-id",
+		"nomap",
+	}
+
+	for _, finding := range findings {
+		tmp := strings.Split(finding.Value, ":")
+
+		if len(tmp) == 0 {
+			continue
+		}
+
+		if len(tmp) > 1 {
+			if tmp[0] != "keep-id" {
+				diags = append(diags, protocol.Diagnostic{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+						End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+					},
+					Severity: &errDiag,
+					Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr016"),
+					Message:  fmt.Sprintf("Invalid value of UserNS: '%s' has no parameters", tmp[0]),
+				})
+			} else {
+				for p := range strings.SplitSeq(tmp[1], ",") {
+					checkUid := strings.HasPrefix(p, "uid=")
+					checkGid := strings.HasPrefix(p, "gid=")
+					if !checkUid && !checkGid {
+						diags = append(diags, protocol.Diagnostic{
+							Range: protocol.Range{
+								Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+								End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+							},
+							Severity: &errDiag,
+							Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr016"),
+							Message:  fmt.Sprintf("Invalid value of UserNS: [uid gid] allowed but found %s", p),
+						})
+					}
+				}
+			}
+		}
+
+		if !slices.Contains(allowdUserNs, tmp[0]) {
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Severity: &errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr016"),
+				Message:  fmt.Sprintf("Invalid value of UserNS: allowed values: '%v' and found %s", allowdUserNs, tmp[0]),
+			})
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr016_test.go
+++ b/internal/syntax/qsr016_test.go
@@ -1,0 +1,99 @@
+package syntax
+
+import "testing"
+
+func TestQSR016_Valid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nUserNS=keep-id",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nUserNS=keep-id:uid=101,gid=101",
+			"test2.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nUserNS=auto",
+			"test3.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nUserNS=host",
+			"test4.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nUserNS=nomap",
+			"test5.container",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr015(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Expected 0 diagnostics, but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR016_NoParameters(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nUserNS=auto:gid=101",
+		"test.container",
+	)
+
+	diags := qsr016(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Exptected 0 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr016" {
+		t.Fatalf("Exptected quadlet-lsp.qsr016 source, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid value of UserNS: 'auto' has no parameters" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestQSR016_KeepIdWrongParameter(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nUserNS=keep-id:gid=101,foo=101",
+		"test.container",
+	)
+
+	diags := qsr016(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Exptected 0 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr016" {
+		t.Fatalf("Exptected quadlet-lsp.qsr016 source, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid value of UserNS: [uid gid] allowed but found foo=101" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}
+
+func TestQSR016_InvalidValue(t *testing.T) {
+	s := NewSyntaxChecker(
+		"[Container]\nUserNS=foo",
+		"test.container",
+	)
+
+	diags := qsr016(s)
+
+	if len(diags) != 1 {
+		t.Fatalf("Exptected 0 diagnostics, but got %d", len(diags))
+	}
+
+	if *diags[0].Source != "quadlet-lsp.qsr016" {
+		t.Fatalf("Exptected quadlet-lsp.qsr016 source, but got %s", *diags[0].Source)
+	}
+
+	if diags[0].Message != "Invalid value of UserNS: allowed values: '[auto host keep-id nomap]' and found foo" {
+		t.Fatalf("Unexpected message: %s", diags[0].Message)
+	}
+}

--- a/internal/syntax/syntax.go
+++ b/internal/syntax/syntax.go
@@ -48,6 +48,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			{"qsr013", qsr013},
 			{"qsr014", qsr014},
 			{"qsr015", qsr015},
+			{"qsr016", qsr016},
 			{"qsr017", qsr017},
 			{"qsr018", qsr018},
 			{"qsr019", qsr019},


### PR DESCRIPTION
## `QSR016` - Invalid value of UserNS specification

**Message**

> Invalid value of UserNS: allowed values: _%reason%_

**Explanation**

Depends on the values of `reason`:

- `%opt% has no paramerets`: Only `keep-id` can have further parameters
- `[uid gid] allowed but found %opt%`: Uses `keep-id` with other parameters than
  `uid` or `gid`
- `allowed values: [auto host keep-id nomap] but found %opt%`: Using invalid
  value of `UserNS`
