### PR TITLE
[syntax] [completion] Fix Environment, Annotation and Label parse

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -172,38 +172,54 @@ Environment='fooVariable=barValue'
 
 **Message**
 
-> Invalid format of Annotation specification
+> Invalid format: _%reason%_
 
 **Explanation**
 
-Annotation must be specified as key-value pairs without having space before or
-after the `=` sign.
+Annotation variables are represented as key-value pairs. If you need to assign a
+value containing spaces or the equals sign to a variable, put quotes around the
+whole assignment. Variable expansion is not performed inside the strings and the
+"$" character has no special meaning.
 
-Examples:
+This option may be specified more than once, in which case all listed variables
+will be set. If the same variable is listed twice, the later setting will
+override the earlier setting. If the empty string is assigned to this option,
+the list of environment variables is reset, all prior assignments have no
+effect.
+
+Correct examples:
 
 ```ini
-Annotation=FOO=BAR   <-- Correct
-Annotation=FOO       <-- Incorrect
-Annotation=FOO = BAR <-- Incorrect
+Annotation=FOO=BAR "MyVar=MyValue" 'foo=bar'
+Annotation=FOO=
+Annotation='fooVariable=barValue'
 ```
 
 ## `QSR009` - Invalid format of Label
 
 **Message**
 
-> Invalid format of Label specification
+> Invalid format: _%reason%_
 
 **Explanation**
 
-Label must be specified as key-value pairs without having space before or after
-the `=` sign.
+Label variables are represented as key-value pairs. If you need to assign a
+value containing spaces or the equals sign to a variable, put quotes around the
+whole assignment. Variable expansion is not performed inside the strings and the
+"$" character has no special meaning.
 
-Examples:
+This option may be specified more than once, in which case all listed variables
+will be set. If the same variable is listed twice, the later setting will
+override the earlier setting. If the empty string is assigned to this option,
+the list of environment variables is reset, all prior assignments have no
+effect.
+
+Correct examples:
 
 ```ini
-Label=FOO=BAR   <-- Correct
-Label=FOO       <-- Incorrect
-Label=FOO = BAR <-- Incorrect
+Label=FOO=BAR "MyVar=MyValue" 'foo=bar'
+Label=FOO=
+Label='fooVariable=barValue'
 ```
 
 ## `QSR010` - Incorrect format of PublishPort

--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -145,19 +145,27 @@ The specified `*.image` or `*.build` file does not exists that is used in the
 
 **Message**
 
-> Invalid format of Environment variable specification
+> Invalid format: _%reason%_
 
 **Explanation**
 
-Environment variable must be specified as key-value pairs without having space
-before or after the `=` sign.
+Environment variables are represented as key-value pairs. If you need to assign
+a value containing spaces or the equals sign to a variable, put quotes around
+the whole assignment. Variable expansion is not performed inside the strings and
+the "$" character has no special meaning.
 
-Examples:
+This option may be specified more than once, in which case all listed variables
+will be set. If the same variable is listed twice, the later setting will
+override the earlier setting. If the empty string is assigned to this option,
+the list of environment variables is reset, all prior assignments have no
+effect.
+
+Correct examples:
 
 ```ini
-Environment=FOO=BAR   <-- Correct
-Environment=FOO       <-- Incorrect
-Environment=FOO = BAR <-- Incorrect
+Environment=FOO=BAR "MyVar=MyValue" 'foo=bar'
+Environment=FOO=
+Environment='fooVariable=barValue'
 ```
 
 ## `QSR008` - Invalid format of Annotation

--- a/internal/data/properties.go
+++ b/internal/data/properties.go
@@ -113,7 +113,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "Annotation=${1:key}=${2:value}\n$0",
+				Macro: "Annotation=\"${1:key}=${2:value}\"\n$0",
 			},
 			{
 				Label: "AutoUpdate",
@@ -216,7 +216,7 @@ $0
 					"Environment=APP_USERNAME=appuser",
 					"```",
 				},
-				Macro: "Environment=${1:name}=${2:value}\n$0",
+				Macro: "Environment=\"${1:name}=${2:value}\"\n$0",
 			},
 			{
 				Label: "EnvironmentFile",
@@ -410,7 +410,7 @@ $0
 					"Label=app=myapp",
 					"```",
 				},
-				Macro: "Label=${1:key}:${2:value}\n$0",
+				Macro: "Label=\"${1:key}=${2:value}\"\n$0",
 			},
 			{
 				Label: "LogDriver",
@@ -903,7 +903,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "Label=${1:key}:${2:value}\n$0",
+				Macro: "Label=\"${1:key}=${2:value}\"\n$0",
 			},
 			{
 				Label: "Network",
@@ -1247,7 +1247,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "Label=${1:key}:${2:value}\n$0",
+				Macro: "Label=\"${1:key}=${2:value}\"\n$0",
 			},
 			{
 				Label: "NetworkDeleteOnStop",
@@ -1354,7 +1354,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "Label=${1:key}:${2:value}\n$0",
+				Macro: "Label=\"${1:key}=${2:value}\"\n$0",
 			},
 			{
 				Label: "Options",

--- a/internal/syntax/qsr003.go
+++ b/internal/syntax/qsr003.go
@@ -31,6 +31,11 @@ func qsr003(s SyntaxChecker) []protocol.Diagnostic {
 		lineNum++
 		line = strings.TrimSpace(line)
 
+		// Skip emptry or comment lines
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+
 		// Read the current section
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 			tSection := line[1 : len(line)-1]

--- a/internal/syntax/qsr003_test.go
+++ b/internal/syntax/qsr003_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestQSR003_ValidProperties(t *testing.T) {
-	s := NewSyntaxChecker("[Container]\nContainerName=app\nExec=run.sh\nUser=root", "test.container")
+	s := NewSyntaxChecker(
+		"[Container]\nContainerName=app\nExec=run.sh\n# Something=comment\nUser=root",
+		"test.container",
+	)
 	s.config = &utils.QuadletConfig{
 		Podman: utils.BuildPodmanVersion(5, 5, 2),
 	}

--- a/internal/syntax/qsr007.go
+++ b/internal/syntax/qsr007.go
@@ -31,7 +31,7 @@ func qsr007(s SyntaxChecker) []protocol.Diagnostic {
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
 				Severity: &errDiag,
-				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr020"),
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr007"),
 				Message:  fmt.Sprintf("Invalid format: %s", err.Error()),
 			})
 			continue
@@ -48,7 +48,7 @@ func qsr007(s SyntaxChecker) []protocol.Diagnostic {
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
 				Severity: &errDiag,
-				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr020"),
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr007"),
 				Message:  fmt.Sprintf("Invalid format: bad delimiter usage at %s", token),
 			})
 		}

--- a/internal/syntax/qsr007_test.go
+++ b/internal/syntax/qsr007_test.go
@@ -53,6 +53,10 @@ func TestQSR007_InvalidUnfinished(t *testing.T) {
 			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
 		}
 
+		if *diags[0].Source != "quadlet-lsp.qsr007" {
+			t.Fatalf("Exptected quadlet-lsp.qsr007 source but got %s", *diags[0].Source)
+		}
+
 		if diags[0].Message != "Invalid format: bad delimiter usage at FOO" {
 			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
 		}

--- a/internal/syntax/qsr008.go
+++ b/internal/syntax/qsr008.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/onlyati/quadlet-lsp/internal/utils"
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -23,32 +23,33 @@ func qsr008(s SyntaxChecker) []protocol.Diagnostic {
 	}
 
 	for _, finding := range findings {
-		index := strings.Index(finding.Value, "=")
-
-		// Check if '=' is missing
-		cond1 := index == -1
-
-		// Cannot be space before or after the '=' sign
-		cond2 := false
-		if !cond1 {
-			cond2 = finding.Value[index-1] == ' '
-
-			if len(finding.Value)-1 > index {
-				cond2 = cond2 || finding.Value[index+1] == ' '
-			}
-		}
-
-		cond3 := index == len(finding.Value)-1
-
-		if cond1 || cond2 || cond3 {
+		tokens, err := splitQuoted(finding.Value)
+		if err != nil {
 			diags = append(diags, protocol.Diagnostic{
 				Range: protocol.Range{
 					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
-				Message:  "Invalid format of Annotation specification",
 				Severity: &errDiag,
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr008"),
+				Message:  fmt.Sprintf("Invalid format: %s", err.Error()),
+			})
+			continue
+		}
+
+		for _, token := range tokens {
+			if quotedKV.MatchString(token) || unquotedKV.MatchString(token) || aposthropeKV.MatchString(token) {
+				continue
+			}
+
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Severity: &errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr008"),
+				Message:  fmt.Sprintf("Invalid format: bad delimiter usage at %s", token),
 			})
 		}
 	}

--- a/internal/syntax/qsr008_test.go
+++ b/internal/syntax/qsr008_test.go
@@ -1,16 +1,31 @@
 package syntax
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestQSR008_Valid(t *testing.T) {
 	variants := []SyntaxChecker{
 		NewSyntaxChecker(
 			"[Container]\nAnnotation=FOO1=BAR\nAnnotation=FOO2=BAR",
-			"test.container",
+			"test1.container",
 		),
 		NewSyntaxChecker(
 			"[Build]\nAnnotation=FOO1=BAR\nAnnotation=FOO2=BAR",
 			"test.build",
+		),
+		NewSyntaxChecker(
+			`[Container]\nAnnotation=FOO=BAR "MyVar=MyValue" 'foo=bar'\n`,
+			"test2.build",
+		),
+		NewSyntaxChecker(
+			`[Container]\nAnnotation=FOO=\n`,
+			"test3.build",
+		),
+		NewSyntaxChecker(
+			`[Container]\nAnnotation='fooVariable=barValue'\n`,
+			"test4.build",
 		),
 	}
 
@@ -29,10 +44,6 @@ func TestQSR008_InvalidUnfinished(t *testing.T) {
 			"[Container]\nAnnotation=FOO",
 			"test1.container",
 		),
-		NewSyntaxChecker(
-			"[Container]\nAnnotation=FOO=",
-			"test2.container",
-		),
 	}
 
 	for _, s := range variants {
@@ -42,7 +53,11 @@ func TestQSR008_InvalidUnfinished(t *testing.T) {
 			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
 		}
 
-		if diags[0].Message != "Invalid format of Annotation specification" {
+		if *diags[0].Source != "quadlet-lsp.qsr008" {
+			t.Fatalf("Exptected quadlet-lsp.qsr007 source but got %s", *diags[0].Source)
+		}
+
+		if diags[0].Message != "Invalid format: bad delimiter usage at FOO" {
 			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
 		}
 
@@ -64,11 +79,12 @@ func TestQSR008_InvalidSpaceFound(t *testing.T) {
 	for _, s := range variants {
 		diags := qsr008(s)
 
-		if len(diags) != 1 {
-			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
+		if len(diags) == 0 {
+			t.Fatalf("Exptected more diagnosis, but got %d at %s", len(diags), s.uri)
 		}
 
-		if diags[0].Message != "Invalid format of Annotation specification" {
+		messageCheck := strings.HasPrefix(diags[0].Message, "Invalid format: bad delimiter usage at")
+		if !messageCheck {
 			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
 		}
 

--- a/internal/syntax/qsr009.go
+++ b/internal/syntax/qsr009.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"strings"
+	"fmt"
 
 	"github.com/onlyati/quadlet-lsp/internal/utils"
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -23,32 +23,33 @@ func qsr009(s SyntaxChecker) []protocol.Diagnostic {
 	}
 
 	for _, finding := range findings {
-		index := strings.Index(finding.Value, "=")
-
-		// Check if '=' is missing
-		cond1 := index == -1
-
-		// Cannot be space before or after the '=' sign
-		cond2 := false
-		if !cond1 {
-			cond2 = finding.Value[index-1] == ' '
-
-			if len(finding.Value)-1 > index {
-				cond2 = cond2 || finding.Value[index+1] == ' '
-			}
-		}
-
-		cond3 := index == len(finding.Value)-1
-
-		if cond1 || cond2 || cond3 {
+		tokens, err := splitQuoted(finding.Value)
+		if err != nil {
 			diags = append(diags, protocol.Diagnostic{
 				Range: protocol.Range{
 					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
 					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
 				},
-				Message:  "Invalid format of Label specification",
 				Severity: &errDiag,
 				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr009"),
+				Message:  fmt.Sprintf("Invalid format: %s", err.Error()),
+			})
+			continue
+		}
+
+		for _, token := range tokens {
+			if quotedKV.MatchString(token) || unquotedKV.MatchString(token) || aposthropeKV.MatchString(token) {
+				continue
+			}
+
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Severity: &errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr009"),
+				Message:  fmt.Sprintf("Invalid format: bad delimiter usage at %s", token),
 			})
 		}
 	}

--- a/internal/syntax/qsr009_test.go
+++ b/internal/syntax/qsr009_test.go
@@ -1,16 +1,31 @@
 package syntax
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestQSR009_Valid(t *testing.T) {
 	variants := []SyntaxChecker{
 		NewSyntaxChecker(
 			"[Container]\nLabel=FOO1=BAR\nLabel=FOO2=BAR",
-			"test.container",
+			"test1.container",
 		),
 		NewSyntaxChecker(
 			"[Build]\nLabel=FOO1=BAR\nLabel=FOO2=BAR",
 			"test.build",
+		),
+		NewSyntaxChecker(
+			`[Container]\nLabel=FOO=BAR "MyVar=MyValue" 'foo=bar'\n`,
+			"test2.build",
+		),
+		NewSyntaxChecker(
+			`[Container]\nLabel=FOO=\n`,
+			"test3.build",
+		),
+		NewSyntaxChecker(
+			`[Container]\nLabel='fooVariable=barValue'\n`,
+			"test4.build",
 		),
 	}
 
@@ -29,10 +44,6 @@ func TestQSR009_InvalidUnfinished(t *testing.T) {
 			"[Container]\nLabel=FOO",
 			"test1.container",
 		),
-		NewSyntaxChecker(
-			"[Container]\nLabel=FOO=",
-			"test2.container",
-		),
 	}
 
 	for _, s := range variants {
@@ -42,7 +53,11 @@ func TestQSR009_InvalidUnfinished(t *testing.T) {
 			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
 		}
 
-		if diags[0].Message != "Invalid format of Label specification" {
+		if *diags[0].Source != "quadlet-lsp.qsr009" {
+			t.Fatalf("Exptected quadlet-lsp.qsr009 source but got %s", *diags[0].Source)
+		}
+
+		if diags[0].Message != "Invalid format: bad delimiter usage at FOO" {
 			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
 		}
 
@@ -64,11 +79,12 @@ func TestQSR009_InvalidSpaceFound(t *testing.T) {
 	for _, s := range variants {
 		diags := qsr009(s)
 
-		if len(diags) != 1 {
-			t.Fatalf("Exptected 1 diagnosis, but got %d at %s", len(diags), s.uri)
+		if len(diags) == 0 {
+			t.Fatalf("Exptected more diagnosis, but got %d at %s", len(diags), s.uri)
 		}
 
-		if diags[0].Message != "Invalid format of Label specification" {
+		messageCheck := strings.HasPrefix(diags[0].Message, "Invalid format: bad delimiter usage at")
+		if !messageCheck {
 			t.Fatalf("Got unexpected error message: '%s' at %s", diags[0].Message, s.uri)
 		}
 

--- a/internal/utils/quadlet_scan_test.go
+++ b/internal/utils/quadlet_scan_test.go
@@ -16,6 +16,7 @@ AutoUpdate=registry
 Environment=ENV1=VALUE1
 Volume=dev-db-volume:/app:rw
 Environment=ENV2=VALUE2
+# Environment=ENV3=VALUE3
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
Same rule below is apply for QSR008 and QSR009 as well. This PR also modify the completion value of these properties, so they are automatically inserted with delimiter.

## `QSR007` - Invalid format of Environment variable

**Message**

> Invalid format: _%reason%_

**Explanation**

Environment variables are represented as key-value pairs. If you need to assign
a value containing spaces or the equals sign to a variable, put quotes around
the whole assignment. Variable expansion is not performed inside the strings and
the "$" character has no special meaning.

This option may be specified more than once, in which case all listed variables
will be set. If the same variable is listed twice, the later setting will
override the earlier setting. If the empty string is assigned to this option,
the list of environment variables is reset, all prior assignments have no
effect.

Correct examples:

```ini
Environment=FOO=BAR "MyVar=MyValue" 'foo=bar'
Environment=FOO=
Environment='fooVariable=barValue'
```
