### PR TITLE
[syntax] QSR020 - Naming of unit is invalid

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -22,6 +22,7 @@
 - [`QSR017` - Pod file does not exists](#qsr017---pod-file-does-not-exists)
 - [`QSR018` - Container cannot publish port with pod](#qsr018---container-cannot-publish-port-with-pod)
 - [`QSR019` - Container cannot have network with pod](#qsr019---container-cannot-have-network-with-pod)
+- [`QSR020` - Naming of unit is invalid](#qsr020---naming-of-unit-is-invalid)
 
 <!-- tocstop -->
 
@@ -354,3 +355,16 @@ When you create a pod, it gets a single network namespace that all containers in
 the pod share. So: Containers in the same pod communicate over localhost
 (127.0.0.1). You assign the network (e.g. --network) when creating the pod, not
 per container.
+
+## `QSR020` - Naming of unit is invalid
+
+**Message**
+
+> Invalid name of unit: _%name%_
+
+**Explanation**
+
+Container, Volume, Pod and Network naming must match with
+`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$` regular expression. The specified name at
+`ContainerName`, `VolumeName`, `PodName` or `Networkname` does not match with
+the expression.

--- a/internal/syntax/common.go
+++ b/internal/syntax/common.go
@@ -18,6 +18,9 @@ var quotedKV = regexp.MustCompile(`^"([A-Za-z_][A-Za-z0-9_]*)=(.*)"$`)
 // regex for quoted 'key=value'
 var aposthropeKV = regexp.MustCompile(`^'([A-Za-z_][A-Za-z0-9_]*)=(.*)'$`)
 
+// regex for name convention, like ContainerName, PodName, VolumeName, NetworkName
+var namingConvention = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
+
 // Function checking what is the extenstion in the URI
 // and return if it is on the allowed array list.
 // Return with the extension (with high capitalized first character)

--- a/internal/syntax/common_test.go
+++ b/internal/syntax/common_test.go
@@ -29,3 +29,19 @@ func TestCanFileBeApplied_Invalid(t *testing.T) {
 		t.Fatalf("expected '', got '%s'", tmp)
 	}
 }
+
+func TestNamingRegexp(t *testing.T) {
+	valid := []string{"foo", "bar"}
+	for _, s := range valid {
+		if !namingConvention.MatchString(s) {
+			t.Fatalf("Regexp should match but it does not: %v %s", namingConvention, s)
+		}
+	}
+
+	invalid := []string{".foo", "*bar", "_foo", "-bar"}
+	for _, s := range invalid {
+		if namingConvention.MatchString(s) {
+			t.Fatalf("Regexp should not match but it does not: %v %s", namingConvention, s)
+		}
+	}
+}

--- a/internal/syntax/qsr020.go
+++ b/internal/syntax/qsr020.go
@@ -1,0 +1,40 @@
+package syntax
+
+import (
+	"fmt"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Verify name of Container, Pod, Network, Volume
+func qsr020(s SyntaxChecker) []protocol.Diagnostic {
+	var diags []protocol.Diagnostic
+
+	var findings []utils.QuadletLine
+	allowedFiles := []string{"container", "pod", "network", "volume"}
+	if c := canFileBeApplied(s.uri, allowedFiles); c != "" {
+		findings = utils.FindItems(
+			s.documentText,
+			c,
+			c+"Name",
+		)
+	}
+
+	for _, finding := range findings {
+		match := namingConvention.MatchString(finding.Value)
+		if !match {
+			diags = append(diags, protocol.Diagnostic{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: finding.LineNumber, Character: 0},
+					End:   protocol.Position{Line: finding.LineNumber, Character: finding.Length},
+				},
+				Severity: &errDiag,
+				Source:   utils.ReturnAsStringPtr("quadlet-lsp.qsr020"),
+				Message:  fmt.Sprintf("Invalid name of unit: %s", finding.Value),
+			})
+		}
+	}
+
+	return diags
+}

--- a/internal/syntax/qsr020_test.go
+++ b/internal/syntax/qsr020_test.go
@@ -1,0 +1,73 @@
+package syntax
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestQSR020_Valid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nContainerName=foo\n",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Volume]\nVolumeName=foo\n",
+			"test1.volume",
+		),
+		NewSyntaxChecker(
+			"[Network]\nNetworkName=foo\n",
+			"test1.network",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nPodName=foo\n",
+			"test1.pod",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr020(s)
+
+		if len(diags) != 0 {
+			t.Fatalf("Exptected 0 diagnostics but got %d at %s", len(diags), s.uri)
+		}
+	}
+}
+
+func TestQSR020_Invalid(t *testing.T) {
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nContainerName=.foo\n",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Volume]\nVolumeName=_foo\n",
+			"test1.volume",
+		),
+		NewSyntaxChecker(
+			"[Network]\nNetworkName=-foo\n",
+			"test1.network",
+		),
+		NewSyntaxChecker(
+			"[Pod]\nPodName=*foo\n",
+			"test1.pod",
+		),
+	}
+
+	for _, s := range cases {
+		diags := qsr020(s)
+
+		if len(diags) != 1 {
+			t.Fatalf("Exptected 1 diagnostics but got %d at %s", len(diags), s.uri)
+		}
+
+		if *diags[0].Source != "quadlet-lsp.qsr020" {
+			t.Fatalf("Unexpected source: %s", *diags[0].Source)
+		}
+
+		matchMessageStart := strings.HasPrefix(diags[0].Message, "Invalid name of unit: ")
+		if !matchMessageStart {
+			t.Fatalf("Unexpected error message: %s", diags[0].Message)
+		}
+	}
+}

--- a/internal/syntax/syntax.go
+++ b/internal/syntax/syntax.go
@@ -52,6 +52,7 @@ func NewSyntaxChecker(documentText, uri string) SyntaxChecker {
 			{"qsr017", qsr017},
 			{"qsr018", qsr018},
 			{"qsr019", qsr019},
+			{"qsr020", qsr020},
 		},
 		commander: utils.CommandExecutor{},
 	}


### PR DESCRIPTION
## `QSR020` - Naming of unit is invalid

**Message**

> Invalid name of unit: _%name%_

**Explanation**

Container, Volume, Pod and Network naming must match with
`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$` regular expression. The specified name at
`ContainerName`, `VolumeName`, `PodName` or `Networkname` does not match with
the expression.
