### PR TITLE
[fix] False positive findings in QSR004

### DIFF
--- a/docs/qsr.md
+++ b/docs/qsr.md
@@ -114,12 +114,18 @@ The specified image name is not fully qualified:
 Image=debian:bookworm-slim
 ```
 
-Use fully qualified image name instead:
+Use fully qualified image name instead. It means that the image must begin with
+`localhost` or with a valid address (e.g.: something.tld). It can also contains
+port number.
+
+Some examples:
 
 ```ini
-[Container]
 Image=docker.io/library/debian:bookworm-slim
-
+Image=ghcr.io/henrygd/beszel/beszel-agent
+Image=localhost/test
+Image=localhost:5000/test
+Image=example.com:5000/test
 ```
 
 ## `QSR005` - Invalid value of AutoUpdate

--- a/internal/syntax/qsr004.go
+++ b/internal/syntax/qsr004.go
@@ -2,16 +2,14 @@ package syntax
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/onlyati/quadlet-lsp/internal/utils"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-var (
-	qsr004AnotherQuadlet      = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*\.(image|build)$`)
-	qsr004FullyQualifiedImage = regexp.MustCompile(
-		`^[a-z0-9]+(?:[._-][a-z0-9]+)*(:[0-9]+)?/[a-z0-9]+(?:[._-][a-z0-9]+)*/[a-z0-9]+(?:[._-][a-z0-9]+)*(?::[\w][\w.-]{0,127}|@sha256:[a-f0-9]{64})$`,
-	)
+var qsr004FullyQualifiedImage = regexp.MustCompile(
+	`^(?:[a-z0-9]+(?:[a-z0-9._-]+)*\.(?:[a-z0-9]+)|localhost)(?::[0-9]+)?(?:\/[a-z0-9]+(?:[a-zA-Z0-9-._]*))+`,
 )
 
 // Check if image name is fully qualified.
@@ -35,7 +33,7 @@ func qsr004(s SyntaxChecker) []protocol.Diagnostic {
 }
 
 func qsr004Action(q utils.QuadletLine, _ utils.PodmanVersion) *protocol.Diagnostic {
-	if qsr004AnotherQuadlet.MatchString(q.Value) {
+	if strings.HasSuffix(q.Value, ".image") || strings.HasSuffix(q.Value, ".build") {
 		return nil
 	}
 	if qsr004FullyQualifiedImage.MatchString(q.Value) {

--- a/internal/syntax/qsr004_test.go
+++ b/internal/syntax/qsr004_test.go
@@ -3,11 +3,35 @@ package syntax
 import "testing"
 
 func TestQSR004_Valid(t *testing.T) {
-	s := NewSyntaxChecker("[Container]\nImage=docker.io/library/debian:bookworm-slim", "test.container")
-	diags := qsr004(s)
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nImage=docker.io/library/debian:bookworm-slim",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nImage=ghcr.io/henrygd/beszel/beszel-agent:latest",
+			"test2.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nImage=localhost/test",
+			"test3.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nImage=localhost:5000/test",
+			"test3.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nImage=example.com:5000/test",
+			"test3.container",
+		),
+	}
 
-	if len(diags) != 0 {
-		t.Errorf("Expected no diagnostics, got %d", len(diags))
+	for _, s := range cases {
+		diags := qsr004(s)
+
+		if len(diags) != 0 {
+			t.Errorf("Expected no diagnostics, got %d at %s", len(diags), s.uri)
+		}
 	}
 }
 
@@ -39,11 +63,27 @@ func TestQSR004_ValidWithBuild(t *testing.T) {
 }
 
 func TestQSR004_Invalid(t *testing.T) {
-	s := NewSyntaxChecker("[Container]\nImage=library/debian:bookworm-slim", "test.container")
-	diags := qsr004(s)
+	cases := []SyntaxChecker{
+		NewSyntaxChecker(
+			"[Container]\nImage=library/debian:bookworm-slim",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nImage=localhost",
+			"test1.container",
+		),
+		NewSyntaxChecker(
+			"[Container]\nImage=localhost/",
+			"test1.container",
+		),
+	}
 
-	if len(diags) != 1 {
-		t.Errorf("Expected 1 diagnostic, got %d", len(diags))
+	for _, s := range cases {
+		diags := qsr004(s)
+
+		if len(diags) != 1 {
+			t.Errorf("Expected 1 diagnostic, got %d at %s", len(diags), s.uri)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Rule is assumed with format like `example.com/org/repo` but some container registry use more qualifiers after the address, so the followings would failed:

```
Image=ghcr.io/henrygd/beszel/beszel-agent
Image=localhost/test
```

## Tasks before merge

- [x] Solve the problem
- [x] Modify documentation
- [x] Add tests