### PR TITLE
[fix] Fix exec value parse

### DIFF
--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -20,7 +20,7 @@ import (
 const lsName = "quadlet"
 
 var (
-	version   = "0.3.0"
+	version   = "0.3.1-rc1"
 	handler   protocol.Handler
 	config    *utils.QuadletConfig
 	documents = utils.NewDocuments()

--- a/internal/utils/quadlet_scan_test.go
+++ b/internal/utils/quadlet_scan_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/onlyati/quadlet-lsp/internal/utils"
+	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
 func TestFindItems(t *testing.T) {
@@ -39,5 +40,179 @@ StartLimitBurst=5
 
 	if findings[0].LineNumber != 6 {
 		t.Fatalf("Expected to find in 6th line, but got %d", findings[0].LineNumber)
+	}
+}
+
+func TestFindItemsWithExec(t *testing.T) {
+	text := `[Unit]
+Description=description
+
+[Container]
+Image=docker.io/library/debian:bookworm-slim
+AutoUpdate=registry
+Environment=ENV1=VALUE1
+Volume=dev-db-volume:/app:rw
+Exec=tail \
+    -f \
+    /dev/null
+Environment=ENV2=VALUE2
+# Environment=ENV3=VALUE3
+
+[Service]
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=5
+`
+	findings := utils.FindItems(text, "[Container]", "Exec")
+
+	if len(findings) != 1 {
+		t.Fatalf("Expected 1 founds, got %d", len(findings))
+	}
+
+	if findings[0].Property != "Exec" {
+		t.Fatalf("Expected to get 'Environment' property, but got %s", findings[0].Property)
+	}
+
+	if findings[0].Value != "tail    -f    /dev/null" {
+		t.Fatalf("Expected to get 'tail    -f    /dev/null' value, but got '%s'", findings[0].Value)
+	}
+
+	if findings[0].LineNumber != 8 {
+		t.Fatalf("Expected to find in 8th line, but got %d", findings[0].LineNumber)
+	}
+}
+
+func TestScanQuadlet(t *testing.T) {
+	text := `[Unit]
+Description=description
+
+[Container]
+Image=docker.io/library/debian:bookworm-slim
+AutoUpdate=registry
+Environment=ENV1=VALUE1
+Volume=dev-db-volume:/app:rw
+Exec=tail \
+    -f \
+    /dev/null
+Environment=ENV2=VALUE2
+# Environment=ENV3=VALUE3
+
+[Service]
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=5
+`
+
+	findings := []struct {
+		p string
+		v string
+		c string
+	}{}
+	mockFn := func(q utils.QuadletLine, _ utils.PodmanVersion) *protocol.Diagnostic {
+		findings = append(findings, struct {
+			p string
+			v string
+			c string
+		}{p: q.Property, v: q.Value, c: q.Section})
+		return nil
+	}
+
+	_ = utils.ScanQadlet(
+		text,
+		utils.PodmanVersion{},
+		map[utils.ScanProperty]struct{}{
+			{Section: "[Container]", Property: "Environment"}: {},
+			{Section: "[Container]", Property: "Exec"}:        {},
+		},
+		mockFn,
+	)
+
+	if len(findings) != 3 {
+		t.Fatalf("execpted 3 finding but got %d", len(findings))
+	}
+
+	if findings[0].c != "[Container]" {
+		t.Fatalf("expected '[Container]' section but got '%s'", findings[0].c)
+	}
+
+	if findings[0].p != "Environment" && findings[0].v != "ENV1=VALUE1" {
+		t.Fatalf("unexpected finding for 0: '%s=%s'", findings[0].p, findings[0].v)
+	}
+
+	if findings[1].p != "Exec" && findings[1].v != "tail    -f    /dev/null" {
+		t.Fatalf("unexpected finding for 1: '%s=%s'", findings[1].p, findings[1].v)
+	}
+
+	if findings[2].p != "Environment" && findings[2].v != "ENV2=VALUE2" {
+		t.Fatalf("unexpected finding for 2: '%s=%s'", findings[2].p, findings[2].v)
+	}
+}
+
+func TestScanQuadletAll(t *testing.T) {
+	text := `[Unit]
+Description=description
+
+[Container]
+Image=docker.io/library/debian:bookworm-slim
+Exec=tail \
+    -f \
+    /dev/null
+AutoUpdate=registry
+
+[Service]
+Restart=on-failure
+
+[Test]
+NoExist=true
+`
+
+	findings := []struct {
+		p string
+		v string
+		c string
+	}{}
+	mockFn := func(q utils.QuadletLine, _ utils.PodmanVersion) *protocol.Diagnostic {
+		findings = append(findings, struct {
+			p string
+			v string
+			c string
+		}{p: q.Property, v: q.Value, c: q.Section})
+		return nil
+	}
+
+	_ = utils.ScanQadlet(
+		text,
+		utils.PodmanVersion{},
+		map[utils.ScanProperty]struct{}{
+			{Section: "*", Property: "*"}: {},
+		},
+		mockFn,
+	)
+
+	if len(findings) != 10 {
+		t.Fatalf("execpted 6 finding but got %d", len(findings))
+	}
+
+	expectedFindings := []struct {
+		p string
+		v string
+		c string
+	}{
+		{c: "[Unit]", p: "", v: ""},
+		{c: "[Unit]", p: "Description", v: "description"},
+		{c: "[Container]", p: "", v: ""},
+		{c: "[Container]", p: "Image", v: "docker.io/library/debian:bookworm-slim"},
+		{c: "[Container]", p: "Exec", v: "tail    -f    /dev/null"},
+		{c: "[Container]", p: "AutoUpdate", v: "registry"},
+		{c: "[Service]", p: "", v: ""},
+		{c: "[Service]", p: "Restart", v: "on-failure"},
+		{c: "[Test]", p: "", v: ""},
+		{c: "[Test]", p: "NoExist", v: "true"},
+	}
+
+	for i, e := range expectedFindings {
+		if findings[i] != e {
+			t.Fatalf("unexpected finding: %+v", findings[0])
+		}
 	}
 }


### PR DESCRIPTION
If the Exec was split to multiple line, like this:

```
[Unit]
Description=PostgreSQL database
BindsTo=db-proxy-5432.service

[Container]
Image=db.image
AutoUpdate=registry
Exec=postgres \
  -c listen_addresses=127.0.0.1
```

Until now that was verified by QSR003 on line basis. This PR fix it. Also fix the value finding routine which also was reading just one line.