### PR TITLE
[fix] QSR021 accept all systemd unit types

### DIFF
--- a/internal/syntax/qsr021.go
+++ b/internal/syntax/qsr021.go
@@ -9,7 +9,9 @@ import (
 )
 
 var (
-	qsr021ServiceNamingConvention = regexp.MustCompile(`^[a-zA-Z0-9][@a-zA-Z0-9_.-]*\.service$`)
+	qsr021ServiceNamingConvention = regexp.MustCompile(
+		`^[a-zA-Z0-9][@:\a-zA-Z0-9_.-]*\.(?:service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$`,
+	)
 	qsr021QuadletNamingConvention = regexp.MustCompile(
 		`^[a-zA-Z0-9][@a-zA-Z0-9_.-]*\.(image|container|volume|network|kube|pod|build)$`,
 	)

--- a/internal/syntax/qsr021_test.go
+++ b/internal/syntax/qsr021_test.go
@@ -8,73 +8,26 @@ import (
 )
 
 func TestQSR021_InvalidOld(t *testing.T) {
-	cases := []SyntaxChecker{
-		{
-			documentText: "[Unit]\nWants=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequires=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequisite=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nBindsTo=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nPartOf=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nUpholds=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nConflicts=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nBefore=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nAfter=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
+	types := []string{
+		"Wants",
+		"Requires",
+		"Requisite",
+		"BindsTo",
+		"PartOf",
+		"Upholds",
+		"Conflicts",
+		"Before",
+		"After",
 	}
 
-	for _, s := range cases {
+	for _, ty := range types {
+		s := SyntaxChecker{
+			documentText: "[Unit]\n" + ty + "=test1.volume\n[Container]\nImage=my-image.image",
+			uri:          "test1.container",
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 4, 0),
+			},
+		}
 		diags := qsr021(s)
 
 		if len(diags) != 1 {
@@ -93,73 +46,26 @@ func TestQSR021_InvalidOld(t *testing.T) {
 }
 
 func TestQSR021_ValidNew(t *testing.T) {
-	cases := []SyntaxChecker{
-		{
-			documentText: "[Unit]\nWants=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequires=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequisite=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nBindsTo=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nPartOf=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nUpholds=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nConflicts=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nBefore=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nAfter=test1.volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
+	types := []string{
+		"Wants",
+		"Requires",
+		"Requisite",
+		"BindsTo",
+		"PartOf",
+		"Upholds",
+		"Conflicts",
+		"Before",
+		"After",
 	}
 
-	for _, s := range cases {
+	for _, ty := range types {
+		s := SyntaxChecker{
+			documentText: "[Unit]\n" + ty + "=test1.volume\n[Container]\nImage=my-image.image",
+			uri:          "test1.container",
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 5, 2),
+			},
+		}
 		diags := qsr021(s)
 
 		if len(diags) != 0 {
@@ -169,73 +75,26 @@ func TestQSR021_ValidNew(t *testing.T) {
 }
 
 func TestQSR021_ValidOld(t *testing.T) {
-	cases := []SyntaxChecker{
-		{
-			documentText: "[Unit]\nWants=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequires=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequisite=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nBindsTo=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nPartOf=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nUpholds=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nConflicts=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nBefore=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
-		{
-			documentText: "[Unit]\nAfter=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 4, 0),
-			},
-		},
+	types := []string{
+		"Wants",
+		"Requires",
+		"Requisite",
+		"BindsTo",
+		"PartOf",
+		"Upholds",
+		"Conflicts",
+		"Before",
+		"After",
 	}
 
-	for _, s := range cases {
+	for _, ty := range types {
+		s := SyntaxChecker{
+			documentText: "[Unit]\n" + ty + "=test1-volume.service\n[Container]\nImage=my-image.image",
+			uri:          "test1.container",
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 4, 0),
+			},
+		}
 		diags := qsr021(s)
 
 		if len(diags) != 0 {
@@ -245,73 +104,26 @@ func TestQSR021_ValidOld(t *testing.T) {
 }
 
 func TestQSR021_ValidOldWithNew(t *testing.T) {
-	cases := []SyntaxChecker{
-		{
-			documentText: "[Unit]\nWants=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequires=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequisite=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nBindsTo=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nPartOf=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nUpholds=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nConflicts=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nBefore=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nAfter=test1-volume.service\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
+	types := []string{
+		"Wants",
+		"Requires",
+		"Requisite",
+		"BindsTo",
+		"PartOf",
+		"Upholds",
+		"Conflicts",
+		"Before",
+		"After",
 	}
 
-	for _, s := range cases {
+	for _, ty := range types {
+		s := SyntaxChecker{
+			documentText: "[Unit]\n" + ty + "=test1-volume.service\n[Container]\nImage=my-image.image",
+			uri:          "test1.container",
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 5, 2),
+			},
+		}
 		diags := qsr021(s)
 
 		if len(diags) != 0 {
@@ -348,73 +160,25 @@ func TestQSR021_ValidWantsTemplate(t *testing.T) {
 }
 
 func TestQSR021_Invalid(t *testing.T) {
-	cases := []SyntaxChecker{
-		{
-			documentText: "[Unit]\nWants=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequires=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nRequisite=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nBindsTo=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nPartOf=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nUpholds=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nConflicts=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nBefore=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
-		{
-			documentText: "[Unit]\nAfter=test1-volume\n[Container]\nImage=my-image.image",
-			uri:          "test1.container",
-			config: &utils.QuadletConfig{
-				Podman: utils.BuildPodmanVersion(5, 5, 2),
-			},
-		},
+	types := []string{
+		"Wants",
+		"Requires",
+		"Requisite",
+		"BindsTo",
+		"PartOf",
+		"Upholds",
+		"Conflicts",
+		"Before",
+		"After",
 	}
-
-	for _, s := range cases {
+	for _, ty := range types {
+		s := SyntaxChecker{
+			documentText: "[Unit]\n" + ty + "=test1-volume\n[Container]\nImage=my-image.image",
+			uri:          "test1.container",
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 5, 2),
+			},
+		}
 		diags := qsr021(s)
 
 		if len(diags) != 1 {
@@ -428,6 +192,46 @@ func TestQSR021_Invalid(t *testing.T) {
 		checkMessage := strings.HasPrefix(diags[0].Message, "Invalid depdency is specified: ")
 		if !checkMessage {
 			t.Fatalf("Unexpected message returned: %s", diags[0].Message)
+		}
+	}
+}
+
+func TestQSR021_TestServiceRegexp(t *testing.T) {
+	inputs := []string{
+		"foobar@:\\_.-.service",
+		"foobar@:\\_.-.socket",
+		"foobar@:\\_.-.device",
+		"foobar@:\\_.-.mount",
+		"foobar@:\\_.-.automount",
+		"foobar@:\\_.-.swap",
+		"foobar@:\\_.-.target",
+		"foobar@:\\_.-.path",
+		"foobar@:\\_.-.timer",
+		"foobar@:\\_.-.slice",
+		"foobar@:\\_.-.scope",
+	}
+
+	for _, s := range inputs {
+		if !qsr021ServiceNamingConvention.MatchString(s) {
+			t.Fatalf("expected to match but does not: %s", s)
+		}
+	}
+}
+
+func TestQSR021_TestQuadletRegexp(t *testing.T) {
+	inputs := []string{
+		"foobar@_.-.image",
+		"foobar@_.-.container",
+		"foobar@_.-.volume",
+		"foobar@_.-.network",
+		"foobar@_.-.kube",
+		"foobar@_.-.pod",
+		"foobar@_.-.build",
+	}
+
+	for _, s := range inputs {
+		if !qsr021QuadletNamingConvention.MatchString(s) {
+			t.Fatalf("expected to match but does not: %s", s)
 		}
 	}
 }


### PR DESCRIPTION
Based on systemd documentation:

> Valid unit names consist of a "unit name prefix", and a suffix specifying the unit type which begins with a dot. The "unit name prefix" must consist of one or more valid characters (ASCII letters, digits, ":", "-", "_", ".", and "\"). The total length of the unit name including the suffix must not exceed 255 characters. The unit type suffix must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".slice", or ".scope".