### PR TITLE
[feature] Add drop-in file support

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -28,6 +28,11 @@ Features below are implemented to support following file extensions:
 - `*.pod`
 - `*.build`
 
+Language server also support the drop-ins directories. For example having
+`foo.container`. Settings can be override or added in a drop-ins file like
+`foo.container.d/10-ports.conf`. On this way settings can be override without
+changing the actual Quadlet files.
+
 > [!IMPORTANT]
 >
 > Only Quadlet part has features in the files below. The generic systemd related

--- a/internal/syntax/common.go
+++ b/internal/syntax/common.go
@@ -2,6 +2,7 @@ package syntax
 
 import (
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -10,9 +11,24 @@ import (
 
 // Function checking what is the extenstion in the URI
 // and return if it is on the allowed array list.
+// This also check for drop-ins file like foo.contaner.d/10-ports.conf.
 // Return with the extension (with high capitalized first character)
 // if matches on list. If does not match return value is empty.
 func canFileBeApplied(uri string, allowed []string) string {
+	// First check for drop-ins
+	if strings.HasSuffix(uri, ".conf") {
+		tmp := strings.Split(uri, string(os.PathSeparator))
+		if len(tmp) > 2 {
+			parentDirectory := tmp[len(tmp)-2]
+			for _, item := range allowed {
+				if strings.HasSuffix(parentDirectory, item+".d") {
+					return "[" + utils.FirstCharacterToUpper(item) + "]"
+				}
+			}
+		}
+	}
+
+	// Check for actual file extension like foo.container
 	tmp := strings.Split(uri, ".")
 	ext := tmp[len(tmp)-1]
 	if slices.Contains(allowed, ext) {

--- a/internal/syntax/common_test.go
+++ b/internal/syntax/common_test.go
@@ -10,12 +10,27 @@ func TestCanFileBeApplied_Valid(t *testing.T) {
 		t.Fatalf("expected 'Container', got '%s'", tmp)
 	}
 
+	tmp = canFileBeApplied("file:///foo.container.d/10-ports.conf", list)
+	if tmp != "[Container]" {
+		t.Fatalf("expected 'Container', got '%s'", tmp)
+	}
+
 	tmp = canFileBeApplied("file:///foo.image", list)
 	if tmp != "[Image]" {
 		t.Fatalf("expected 'Image', got '%s'", tmp)
 	}
 
+	tmp = canFileBeApplied("file:///foo.image.d/auth.conf", list)
+	if tmp != "[Image]" {
+		t.Fatalf("expected 'Image', got '%s'", tmp)
+	}
+
 	tmp = canFileBeApplied("file:///foo.volume", list)
+	if tmp != "[Volume]" {
+		t.Fatalf("expected 'Volume', got '%s'", tmp)
+	}
+
+	tmp = canFileBeApplied("file:///foo.volume.d/driver.conf", list)
 	if tmp != "[Volume]" {
 		t.Fatalf("expected 'Volume', got '%s'", tmp)
 	}
@@ -25,6 +40,11 @@ func TestCanFileBeApplied_Invalid(t *testing.T) {
 	list := []string{"container", "volume", "image"}
 
 	tmp := canFileBeApplied("file:///foo.network", list)
+	if tmp != "" {
+		t.Fatalf("expected '', got '%s'", tmp)
+	}
+
+	tmp = canFileBeApplied("file:///foo.conf", list)
 	if tmp != "" {
 		t.Fatalf("expected '', got '%s'", tmp)
 	}


### PR DESCRIPTION
**Describe the problem why the PR is open**
https://github.com/onlyati/quadlet-lsp/issues/93

**Describe the solution**
When checking for Quadlet file type in syntax, hover then check also the parent directory if files extension is `*.conf`. If they are ends like `container.d`, `image.d`, etc. then also parse that conf member too.

**Checklist**
- [ x] Feature implementation
- [ x] Update documents
- [ x] Write unit tests
