### PR TITLE
[repo] Reduce go version due to builds on copr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onlyati/quadlet-lsp
 
-go 1.25.1
+go 1.24.4
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0

--- a/mise.toml
+++ b/mise.toml
@@ -11,5 +11,5 @@ description = "Run unit tests"
 run = "go test -race ./..."
 
 [tools]
-go = "1.25.1"
+go = "1.24.4"
 goreleaser = "2.12.1"

--- a/quadlet-lsp.spec
+++ b/quadlet-lsp.spec
@@ -7,7 +7,7 @@ License:        GPLv3
 URL:            https://github.com/onlyati/quadlet-lsp
 Source0:        https://github.com/onlyati/quadlet-lsp/archive/refs/tags/v%{version}.tar.gz
 
-BuildRequires:  golang >= 1.22
+BuildRequires:  golang >= 1.24.4
 BuildRequires:  git
 
 %description


### PR DESCRIPTION
**Describe the problem why the PR is open**
Go 1.25 do not exists on RHEL 10 and other distribution, so COPR is unable to build the project.

**Describe the solution**
Set the minimum required Go version to 1.24.4
