### PR TITLE
[feature] Add formatting

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -6,6 +6,7 @@
 - [Syntax checking](#syntax-checking)
     * [Disable syntax rule per file](#disable-syntax-rule-per-file)
 - [Configuration file](#configuration-file)
+- [Format file](#format-file)
 - [Hover menu](#hover-menu)
     * [Hover on properties](#hover-on-properties)
     * [Hover on systemd specifiers](#hover-on-systemd-specifiers)
@@ -105,6 +106,69 @@ Example for file:
   "disabled": ["qsr013", "qsr004"],
   "podmanVersion": "5.4.0"
 }
+```
+
+## Format file
+
+Language server has feature to format the document. Format has the following
+rules:
+
+- Line width does not exceed the 80 character width. If a line is longer, then
+  line is split by using `\` continuation sign.
+- Each comment line is removed, except from the beginning of the file.
+- Properties are grouped based on topics.
+- Within the topics, settings are sorted based on alphabetical order.
+
+Example formatted file:
+
+```ini
+# disable-qsr: qsr014 qsr013
+#
+# File name: gitea.container
+
+[Unit]
+Description=Gitea application
+Wants=gitea-db.service
+
+[Container]
+# Base options
+AutoUpdate=registry
+Image=docker.io/gitea/gitea:latest-rootless
+Pod=gitea.pod
+
+# Storage options
+Volume=/etc/localtime:/etc/localtime:ro
+Volume=/etc/timezone:/etc/timezone:ro
+
+# Environment options
+Environment=GITEA__database__DB_TYPE=postgres
+Environment=GITEA__database__HOST=127.0.0.1
+Environment=GITEA__database__NAME=gitea
+Environment=GITEA__database__USER=gitea
+
+# Secret options
+Secret=gitea-db-password,type=env,target=GITEA__database__PASSWD
+Secret=gitea-smtp-password,type=env,target=GITEA__mailer__PASSWD
+
+# Healthcheck options
+HealthCmd=/bin/curlcurl -k --fail --connect-timeout 5 \
+  https://127.0.0.1:3000/api/healthz
+HealthRetries=10
+HealthStartPeriod=15s
+HealthTimeout=15s
+
+# Other options
+LogDriver=journald
+UserNS=keep-id
+
+[Service]
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=5
+
+[Install]
+WantedBy=default.target
+
 ```
 
 ## Hover menu

--- a/internal/data/properties.go
+++ b/internal/data/properties.go
@@ -4,14 +4,30 @@
 // can be used by other packages like completion, syntax, etc.
 package data
 
-import "github.com/onlyati/quadlet-lsp/internal/utils"
+import (
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+)
+
+type FormatGroup string
+
+const (
+	FormatGroupNetwork     FormatGroup = "Network"
+	FormatGroupStorage     FormatGroup = "Storage"
+	FormatGroupEnvironment FormatGroup = "Environment"
+	FormatGroupBase        FormatGroup = "Base"
+	FormatGroupHealth      FormatGroup = "Healthcheck"
+	FormatGroupLabel       FormatGroup = "Label"
+	FormatGroupSecret      FormatGroup = "Secret"
+	FormatGroupOther       FormatGroup = "Other"
+)
 
 type PropertyMapItem struct {
-	Label      string
-	Hover      []string
-	Parameters []string
-	Macro      string
-	MinVersion utils.PodmanVersion
+	Label       string
+	Hover       []string
+	Parameters  []string
+	Macro       string
+	MinVersion  utils.PodmanVersion
+	FormatGroup FormatGroup
 }
 
 type CategoryPropertyItem struct {
@@ -264,7 +280,8 @@ $0
 					"",
 					"Equivalent to the Podman --add-host option. This key can be listed multiple times.",
 				},
-				Macro: "AddHost=${1:hostname}:${2:ip}\n$0",
+				Macro:       "AddHost=${1:hostname}:${2:ip}\n$0",
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "Annotation",
@@ -283,7 +300,8 @@ $0
 					"- `registry`: Requires a fully-qualified image reference (e.g., quay.io/podman/stable:latest) to be used to create the container. This enforcement is necessary to know which image to actually check and pull. If an image ID was used, Podman does not know which image to check/pull anymore.",
 					"- `local`: Tells Podman to compare the image a container is using to the image with its raw name in local storage. If an image is updated locally, Podman simply restarts the systemd unit executing the container.",
 				},
-				Parameters: []string{"registry", "local"},
+				Parameters:  []string{"registry", "local"},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "CgroupsMode",
@@ -300,6 +318,7 @@ $0
 				Hover: []string{
 					"The (optional) name of the Podman container. If this is not specified, the default value of `systemd-%N` is used, which is the same as the service name but with a `systemd-` prefix to avoid conflicts with user-managed containers.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "ContainersConfModule",
@@ -330,6 +349,7 @@ $0
 					"9.9.9.9",
 					"149.112.112.112",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "DNSOption",
@@ -338,6 +358,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "DNSSearch",
@@ -346,6 +367,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "DropCapability",
@@ -365,6 +387,7 @@ $0
 				Hover: []string{
 					"Override the default ENTRYPOINT from the image. Equivalent to the Podman --entrypoint option. Specify multi option commands in the form of a JSON string.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "Environment",
@@ -376,19 +399,22 @@ $0
 					"Environment=APP_USERNAME=appuser",
 					"```",
 				},
-				Macro: "Environment=\"${1:name}=${2:value}\"\n$0",
+				Macro:       "Environment=\"${1:name}=${2:value}\"\n$0",
+				FormatGroup: FormatGroupEnvironment,
 			},
 			{
 				Label: "EnvironmentFile",
 				Hover: []string{
 					"Use a line-delimited file to set environment variables in the container. The path may be absolute or relative to the location of the unit file. This key may be used multiple times, and the order persists when passed to `podman run`.",
 				},
+				FormatGroup: FormatGroupEnvironment,
 			},
 			{
 				Label: "EnvironmentHost",
 				Hover: []string{
 					"Use the host environment inside of the container.",
 				},
+				FormatGroup: FormatGroupEnvironment,
 			},
 			{
 				Label: "Exec",
@@ -401,6 +427,7 @@ $0
 					"",
 					"Another way to describe this is that it works the same way as the [args field in a Kubernetes pod](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell).",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "ExposeHostPort",
@@ -409,6 +436,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "GIDMap",
@@ -445,12 +473,14 @@ $0
 				Hover: []string{
 					"Set or alter a healthcheck command for a container. A value of none disables existing healthchecks. Equivalent to the Podman `--health-cmd option`.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthInterval",
 				Hover: []string{
 					"Set an interval for the healthchecks. An interval of disable results in no automatic timer setup. Equivalent to the Podman `--health-interval` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthLogDestination",
@@ -461,78 +491,91 @@ $0
 					"- `directory`: creates a log file named `<container-ID>-healthcheck.log` with HealthCheck logs in the specified directory.",
 					"- `events_logger`: The log will be written with logging mechanism set by events_logger. It also saves the log to a default directory, for performance on a system with a large number of logs.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthMaxLogCount",
 				Hover: []string{
 					"Set maximum number of attempts in the HealthCheck log file. (‘0’ value means an infinite number of attempts in the log file) (Default: 5 attempts) Equivalent to the Podman `--Health-max-log-count` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthMaxLogSize",
 				Hover: []string{
 					"Set maximum length in characters of stored HealthCheck log. (“0” value means an infinite log length) (Default: 500 characters) Equivalent to the Podman `--Health-max-log-size` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthOnFailure",
 				Hover: []string{
 					"Action to take once the container transitions to an unhealthy state. The “kill” action in combination integrates best with systemd. Once the container turns unhealthy, it gets killed, and systemd restarts the service. Equivalent to the Podman `--health-on-failure` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthRetries",
 				Hover: []string{
 					"The number of retries allowed before a healthcheck is considered to be unhealthy. Equivalent to the Podman `--health-retries` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthStartPeriod",
 				Hover: []string{
 					"The initialization time needed for a container to bootstrap. Equivalent to the Podman `--health-start-period` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthStartupCmd",
 				Hover: []string{
 					"Set a startup healthcheck command for a container. Equivalent to the Podman `--health-startup-cmd` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthStartupInterval",
 				Hover: []string{
 					"Set an interval for the startup healthcheck. An interval of disable results in no automatic timer setup. Equivalent to the Podman `--health-startup-interval` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthStartupRetries",
 				Hover: []string{
 					"The number of attempts allowed before the startup healthcheck restarts the container. Equivalent to the Podman `--health-startup-retries` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthStartupSuccess",
 				Hover: []string{
 					"The number of successful runs required before the startup healthcheck succeeds and the regular healthcheck begins. Equivalent to the Podman `--health-startup-success` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthStartupTimeout",
 				Hover: []string{
 					"The maximum time a startup healthcheck command has to complete before it is marked as failed. Equivalent to the Podman `--health-startup-timeout` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HealthTimeout",
 				Hover: []string{
 					"The maximum time allowed to complete the healthcheck before an interval is considered failed. Equivalent to the Podman `--health-timeout` option.",
 				},
+				FormatGroup: FormatGroupHealth,
 			},
 			{
 				Label: "HostName",
 				Hover: []string{
 					"Sets the host name that is available inside the container. Equivalent to the Podman --hostname option.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "Image",
@@ -545,18 +588,21 @@ $0
 					"- If the name of the image ends with `.image`, Quadlet will use the image pulled by the corresponding `.image` file, and the generated systemd service contains a dependency on the `$name-image.service` (or the service name set in the .image file). Note that the corresponding `.image` file must exist.",
 					"- If the name of the image ends with `.build`, Quadlet will use the image built by the corresponding `.build` file, and the generated systemd service contains a dependency on the `$name-build.service`. Note: the corresponding `.build` file must exist.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "IP",
 				Hover: []string{
 					"Specify a static IPv4 address for the container, for example **10.88.64.128**. Equivalent to the Podman `--ip` option.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "IP6",
 				Hover: []string{
 					"Specify a static IPv6 address for the container, for example **fd46:db93:aa76:ac37::10**. Equivalent to the Podman `--ip6` option.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "Label",
@@ -570,7 +616,8 @@ $0
 					"Label=app=myapp",
 					"```",
 				},
-				Macro: "Label=\"${1:key}=${2:value}\"\n$0",
+				Macro:       "Label=\"${1:key}=${2:value}\"\n$0",
+				FormatGroup: FormatGroupLabel,
 			},
 			{
 				Label: "LogDriver",
@@ -610,6 +657,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupStorage,
 			},
 			{
 				Label: "Network",
@@ -623,6 +671,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "NetworkAlias",
@@ -631,12 +680,14 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "NoNewPrivileges",
 				Hover: []string{
 					"If enabled, this disables the container processes from gaining additional privileges via things like setuid and file capabilities. Defaults to false.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "Notify",
@@ -661,6 +712,7 @@ $0
 					"",
 					"Quadlet will add all the necessary parameters to link between the container and the pod and between their corresponding services.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "PodmanArgs",
@@ -671,6 +723,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "PublishPort",
@@ -683,7 +736,8 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "PublishPort=${1:interface}:${2:exposed}:${3:source}\n$0",
+				Macro:       "PublishPort=${1:interface}:${2:exposed}:${3:source}\n$0",
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "Pull",
@@ -696,6 +750,7 @@ $0
 					"never",
 					"newer",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "ReadOnly",
@@ -772,7 +827,8 @@ $0
 				Hover: []string{
 					"Use a Podman secret in the container either as a file or an environment variable. This is equivalent to the Podman `--secret` option and generally has the form `secret[,opt=opt ...]`",
 				},
-				Macro: "Secret=${1:secret},type=${2:type},target=${3:target}\n$0",
+				Macro:       "Secret=${1:secret},type=${2:type},target=${3:target}\n$0",
+				FormatGroup: FormatGroupSecret,
 			},
 			{
 				Label: "SecurityLabelDisable",
@@ -943,7 +999,8 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "Volume=${1:destination}:${2:source}\n$0",
+				Macro:       "Volume=${1:destination}:${2:source}\n$0",
+				FormatGroup: FormatGroupStorage,
 			},
 			{
 				Label: "WorkingDir",
@@ -962,6 +1019,7 @@ $0
 					"",
 					"Equivalent to the Podman `--add-host` option. This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "ContainersConfModule",
@@ -986,6 +1044,7 @@ $0
 					"9.9.9.9",
 					"149.112.112.112",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "DNSOption",
@@ -994,6 +1053,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "DNSSearch",
@@ -1002,6 +1062,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "ExitPolicy",
@@ -1043,19 +1104,22 @@ $0
 					"",
 					"Equivalent to the Podman `--hostname` option. This key can be listed multiple times.",
 				},
-				MinVersion: utils.BuildPodmanVersion(5, 5, 0),
+				MinVersion:  utils.BuildPodmanVersion(5, 5, 0),
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "IP",
 				Hover: []string{
 					"Specify a static IPv4 address for the pod, for example **10.88.64.128**. Equivalent to the Podman `--ip` option.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "IP6",
 				Hover: []string{
 					"Specify a static IPv6 address for the pod, for example **fd46:db93:aa76:ac37::10**. Equivalent to the Podman `--ip6` option.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "Label",
@@ -1064,8 +1128,9 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro:      "Label=\"${1:key}=${2:value}\"\n$0",
-				MinVersion: utils.BuildPodmanVersion(5, 6, 0),
+				Macro:       "Label=\"${1:key}=${2:value}\"\n$0",
+				MinVersion:  utils.BuildPodmanVersion(5, 6, 0),
+				FormatGroup: FormatGroupLabel,
 			},
 			{
 				Label: "Network",
@@ -1079,6 +1144,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "NetworkAlias",
@@ -1087,6 +1153,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "PodmanArgs",
@@ -1097,6 +1164,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "PodName",
@@ -1105,6 +1173,7 @@ $0
 					"",
 					"Please note that pods and containers cannot have the same name. So, if PodName is set, it must not conflict with any container.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "PublishPort",
@@ -1119,7 +1188,8 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "PublishPort=${1:interface}:${2:exposed}:${3:source}\n$0",
+				Macro:       "PublishPort=${1:interface}:${2:exposed}:${3:source}\n$0",
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "ServiceName",
@@ -1128,6 +1198,7 @@ $0
 					"",
 					"Note, the name should not include the `.service` file extension",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "ShmSize",
@@ -1182,7 +1253,8 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "Volume=${1:destination}:${2:source}\n$0",
+				Macro:       "Volume=${1:destination}:${2:source}\n$0",
+				FormatGroup: FormatGroupStorage,
 			},
 		},
 		"Kube": {
@@ -1194,7 +1266,8 @@ $0
 					"- `local`: Tells Podman to compare the image a container is using to the image with its raw name in local storage. If an image is updated locally, Podman simply restarts the systemd unit executing the Kubernetes Quadlet.",
 					"- `name/(local|registry)`: Tells Podman to perform the `local` or `registry` autoupdate on the specified container name.",
 				},
-				Parameters: []string{"registry", "local"},
+				Parameters:  []string{"registry", "local"},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "ConfigMap",
@@ -1265,6 +1338,7 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 			{
 				Label: "PublishPort",
@@ -1277,7 +1351,8 @@ $0
 					"",
 					"This key can be listed multiple times.",
 				},
-				Macro: "PublishPort=${1:interface}:${2:exposed}:${3:source}\n$0",
+				Macro:       "PublishPort=${1:interface}:${2:exposed}:${3:source}\n$0",
+				FormatGroup: FormatGroupNetwork,
 			},
 			{
 				Label: "SetWorkingDirectory",
@@ -1304,6 +1379,7 @@ $0
 				Hover: []string{
 					"The path, absolute or relative to the location of the unit file, to the Kubernetes YAML file to use.",
 				},
+				FormatGroup: FormatGroupBase,
 			},
 		},
 		"Network": {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,0 +1,213 @@
+// Package format
+//
+// This package contains the format request related actions.
+package format
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/data"
+)
+
+type documentSchema struct {
+	header   []string
+	sections map[string]map[data.FormatGroup][]sectionElement
+}
+
+type sectionElement struct {
+	property string
+	value    string
+}
+
+type sectionElements []sectionElement
+
+func (a sectionElements) Len() int      { return len(a) }
+func (a sectionElements) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a sectionElements) Less(i, j int) bool {
+	if a[i].property == a[j].property {
+		return a[i].value < a[j].value
+	} else {
+		return a[i].property < a[j].property
+	}
+}
+
+func FormatDocument(text string) string {
+	inSection := ""
+	lastLine := ""
+	var lastFormatGroup data.FormatGroup
+	document := documentSchema{}
+	document.header = make([]string, 0)
+	document.sections = make(map[string]map[data.FormatGroup][]sectionElement, 0)
+
+	// Read the whole file
+	for line := range strings.SplitSeq(text, "\n") {
+		line := strings.TrimSpace(line)
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimPrefix(line, "[")
+			section = strings.TrimSuffix(section, "]")
+			inSection = section
+			document.sections[inSection] = make(map[data.FormatGroup][]sectionElement)
+			lastLine = ""
+			continue
+		}
+
+		if inSection == "" {
+			// Keep the first lines as is
+			document.header = append(document.header, line)
+		}
+
+		if inSection != "" {
+			// Parse the lines to the map except comment and empty lines
+			if strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+				continue
+			}
+
+			if strings.HasSuffix(lastLine, " \\") {
+				// If this is a continuation then just append to the last item's value
+				actualValue := document.sections[inSection][lastFormatGroup][len(document.sections[inSection][lastFormatGroup])-1].value
+				actualValue = strings.TrimSuffix(actualValue, " \\")
+				actualValue = strings.TrimSpace(actualValue)
+
+				document.sections[inSection][lastFormatGroup][len(document.sections[inSection][lastFormatGroup])-1].value = actualValue + " " + line
+			} else {
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) != 2 {
+					continue
+				}
+				// If this is a new line then just parse it
+				formatterGroup := data.FormatGroupOther
+				for _, p := range data.PropertiesMap[inSection] {
+					if p.Label == parts[0] {
+						if p.FormatGroup != "" {
+							formatterGroup = p.FormatGroup
+						}
+						break
+					}
+				}
+
+				lastFormatGroup = formatterGroup
+				if len(document.sections[inSection][formatterGroup]) > 0 {
+					document.sections[inSection][formatterGroup] = append(document.sections[inSection][formatterGroup], sectionElement{
+						property: parts[0],
+						value:    parts[1],
+					})
+				} else {
+					document.sections[inSection][formatterGroup] = []sectionElement{
+						{
+							property: parts[0],
+							value:    parts[1],
+						},
+					}
+				}
+			}
+		}
+
+		lastLine = line
+	}
+
+	// Sort the arrays
+	for k, v := range document.sections {
+		if k == "Install" || k == "Unit" || k == "Service" {
+			// Remained untouced
+			continue
+		}
+
+		for _, vv := range v {
+			sort.Sort(sectionElements(vv))
+		}
+	}
+
+	// Generate the new text
+	newText := ""
+
+	for _, l := range document.header {
+		newText += l + "\n"
+	}
+
+	sectionSeq := []string{
+		"Unit",
+		"Image",
+		"Container",
+		"Volume",
+		"Network",
+		"Kube",
+		"Pod",
+		"Build",
+		"Service",
+		"Install",
+	}
+
+	printSeq := []data.FormatGroup{
+		data.FormatGroupBase,
+		data.FormatGroupLabel,
+		data.FormatGroupStorage,
+		data.FormatGroupNetwork,
+		data.FormatGroupEnvironment,
+		data.FormatGroupSecret,
+		data.FormatGroupHealth,
+		data.FormatGroupOther,
+	}
+
+	for _, k := range sectionSeq {
+		if v, ok := document.sections[k]; ok {
+			newText += "[" + k + "]\n"
+
+			for _, p := range printSeq {
+				if vv, ok := v[p]; ok {
+					if k != "Install" && k != "Unit" && k != "Service" {
+						newText += "# " + string(p) + " options\n"
+					}
+					for _, element := range vv {
+						newLine := element.property + "=" + strings.TrimSpace(element.value)
+						if len(newLine) <= 80 {
+							// Short line, one line is enough
+							newText += newLine + "\n"
+						} else {
+							// Long line, split to multiple ones
+							newText += wrapLine(newLine, 80)
+						}
+					}
+					newText += "\n"
+				}
+			}
+
+		}
+	}
+
+	return newText
+}
+
+func wrapLine(s string, width int) string {
+	offset := 2 // The ' \' continuation sign
+	o := ""
+	for len(s) >= width-offset {
+		pos := width - offset
+		part := ""
+		if s[width-offset] == ' ' {
+			part = s[:pos] + " \\"
+		} else {
+			for i := pos; ; i-- {
+				if s[i] == ' ' {
+					pos = i
+					break
+				}
+			}
+			part = s[:pos] + " \\"
+		}
+
+		if offset == 4 {
+			o += " " + part + "\n"
+		} else {
+			o += part + "\n"
+		}
+
+		s = s[pos:]
+
+		offset = 4 // For further lines line start with '  '
+	}
+
+	o += " " + s + "\n"
+	return o
+}

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,0 +1,250 @@
+package format
+
+import "testing"
+
+func Test_FormatDocument(t *testing.T) {
+	source := `# disable-qsr: qsr014
+# disable-qsr: qsr015
+
+[Unit]
+Description=Nextcloud instance
+
+[Container]
+Pod=nc.pod
+AutoUpdate=registry
+
+Memory=512M
+
+# Volumes
+Volume=nc-app.volume:/var/www/html
+
+# Environment variables
+
+# Database variables
+Environment=POSTGRES_USER=nextclouduser
+Environment=POSTGRES_DB=nextcloud
+Environment=POSTGRES_HOST=127.0.0.1
+Secret=nc-db-password,type=env,target=POSTGRES_PASSWORD
+
+# Default admin user and password
+Environment=NEXTCLOUD_ADMIN_USER=ati
+Secret=nc-admin-pw,type=env,target=NEXTCLOUD_ADMIN_PASSWORD
+
+# Redis variables
+Environment=REDIS_HOST=127.0.0.1
+Environment=REDIS_PORT=6379
+
+# SMTP variables
+Environment=SMTP_HOST=smtp.rackhost.hu
+Environment=SMTP_SECURE=tls
+Environment=SMTP_PORT=587
+Environment=SMTP_NAME=noreply@thinkaboutit.tech
+Environment=SMTP_DOMAIN=thinkaboutit.tech
+Environment=SMTP_FROM_ADDRESS=noreply@thinkaboutit.tech
+Secret=tai-noreply,type=env,target=SMTP_PASSWORD
+
+# S3 bucket as primary storage
+Environment=OBJECTSTORE_S3_BUCKET=dakota-bazooka-metaphor-axes
+Environment=OBJECTSTORE_S3_REGION=de
+Environment=OBJECTSTORE_S3_HOST=s3.de.io.cloud.ovh.net
+Secret=ovh-s3-access-key,type=env,target=OBJECTSTORE_S3_KEY
+Secret=ovh-s3-secret-key,type=env,target=OBJECTSTORE_S3_SECRET
+
+PublishPort=8080:8080
+
+
+[Service]
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=5
+
+[Install]
+WantedBy=default.target
+`
+
+	expected := `# disable-qsr: qsr014
+# disable-qsr: qsr015
+
+[Unit]
+Description=Nextcloud instance
+
+[Container]
+# Base options
+AutoUpdate=registry
+Pod=nc.pod
+
+# Storage options
+Volume=nc-app.volume:/var/www/html
+
+# Network options
+PublishPort=8080:8080
+
+# Environment options
+Environment=NEXTCLOUD_ADMIN_USER=ati
+Environment=OBJECTSTORE_S3_BUCKET=dakota-bazooka-metaphor-axes
+Environment=OBJECTSTORE_S3_HOST=s3.de.io.cloud.ovh.net
+Environment=OBJECTSTORE_S3_REGION=de
+Environment=POSTGRES_DB=nextcloud
+Environment=POSTGRES_HOST=127.0.0.1
+Environment=POSTGRES_USER=nextclouduser
+Environment=REDIS_HOST=127.0.0.1
+Environment=REDIS_PORT=6379
+Environment=SMTP_DOMAIN=thinkaboutit.tech
+Environment=SMTP_FROM_ADDRESS=noreply@thinkaboutit.tech
+Environment=SMTP_HOST=smtp.rackhost.hu
+Environment=SMTP_NAME=noreply@thinkaboutit.tech
+Environment=SMTP_PORT=587
+Environment=SMTP_SECURE=tls
+
+# Secret options
+Secret=nc-admin-pw,type=env,target=NEXTCLOUD_ADMIN_PASSWORD
+Secret=nc-db-password,type=env,target=POSTGRES_PASSWORD
+Secret=ovh-s3-access-key,type=env,target=OBJECTSTORE_S3_KEY
+Secret=ovh-s3-secret-key,type=env,target=OBJECTSTORE_S3_SECRET
+Secret=tai-noreply,type=env,target=SMTP_PASSWORD
+
+# Other options
+Memory=512M
+
+[Service]
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=5
+
+[Install]
+WantedBy=default.target
+
+`
+	newText := FormatDocument(source)
+
+	for i, c := range newText {
+		if i > len(expected) {
+			t.Fatalf("result longer than expected '%s'", newText[i:])
+		}
+		if c != rune(expected[i]) {
+			t.Fatalf("unpextected text after formatting, at position %d: got: '%v' expected: '%v'", i, newText[i-10:i+1], expected[i-10:i+1])
+		}
+	}
+}
+
+func Test_FormatDocumentMultiLine(t *testing.T) {
+	source := ` [Unit]
+Description=PostgreSQL database for Nextcloud
+
+[Container]
+Pod=nc.pod
+Image=docker.io/library/postgres:17
+Exec=postgres \
+  -c listen_addresses=127.0.0.1
+AutoUpdate=registry
+
+Label=asd=asd
+Label= \
+  asd=asd
+Memory=512M
+`
+
+	expected := `[Unit]
+Description=PostgreSQL database for Nextcloud
+
+[Container]
+# Base options
+AutoUpdate=registry
+Exec=postgres -c listen_addresses=127.0.0.1
+Image=docker.io/library/postgres:17
+Pod=nc.pod
+
+# Label options
+Label=asd=asd
+Label=asd=asd
+
+# Other options
+Memory=512M
+
+`
+	newText := FormatDocument(source)
+
+	for i, c := range newText {
+		if i > len(expected) {
+			t.Fatalf("result longer than expected '%s'", newText[i:])
+		}
+		if c != rune(expected[i]) {
+			t.Fatalf("unpextected text after formatting, at position %d: got: '%v' expected: '%v'", i, newText[i-10:i+1], expected[i-10:i+1])
+		}
+	}
+}
+
+func Test_WarpLine(t *testing.T) {
+	source := `[Container]
+# Healthcheck options
+HealthCmd=/bin/curlcurl -k --fail --connect-timeout 5 https://127.0.0.1:3000/api/healthz
+HealthRetries=10
+HealthStartPeriod=15s
+HealthTimeout=15s
+`
+	expected := `[Container]
+# Healthcheck options
+HealthCmd=/bin/curlcurl -k --fail --connect-timeout 5 \
+  https://127.0.0.1:3000/api/healthz
+HealthRetries=10
+HealthStartPeriod=15s
+HealthTimeout=15s
+
+`
+	newText := FormatDocument(source)
+
+	for i, c := range newText {
+		if i >= len(expected) {
+			t.Fatalf("result longer than expected '%s'", newText[i:])
+		}
+		if c != rune(expected[i]) {
+			t.Fatalf("unpextected text after formatting, at position %d: got:\n'%v'\nexpected:\n'%v'", i, newText[i-10:i+1], expected[i-10:i+1])
+		}
+	}
+}
+
+func Test_Unchanged(t *testing.T) {
+	source := `[Container]
+# Healthcheck options
+HealthCmd=/bin/curlcurl -k --fail --connect-timeout 5 \
+  https://127.0.0.1:3000/api/healthz
+HealthRetries=10
+HealthStartPeriod=15s
+HealthTimeout=15s
+
+`
+	newText := FormatDocument(source)
+
+	for i, c := range newText {
+		if i > len(source) {
+			t.Fatalf("result longer than expected '%s'", newText[i:])
+		}
+		if c != rune(source[i]) {
+			t.Fatalf("unpextected text after formatting, at position %d: got:\n'%v'\nexpected:\n'%v'", i, newText[i-10:i+10], source[i-10:i+10])
+		}
+	}
+}
+
+func Test_Warp(t *testing.T) {
+	sources := []string{
+		"HealthCmd=/bin/curl -k --fail  --connect-timeout 5 https://127.0.0.1:3000/api/healthz",
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas nunc mauris, pharetra quis nisi in, eleifend vulputate nisl. Fusce justo mauris, aliquam sed urna feugiat, accumsan egestas tellus. Maecenas ut felis a leo tincidunt volutpat eget a nibh.",
+	}
+	expected := []string{
+		`HealthCmd=/bin/curl -k --fail  --connect-timeout 5 \
+  https://127.0.0.1:3000/api/healthz
+`,
+		`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas nunc mauris, \
+  pharetra quis nisi in, eleifend vulputate nisl. Fusce justo mauris, aliquam \
+  sed urna feugiat, accumsan egestas tellus. Maecenas ut felis a leo \
+  tincidunt volutpat eget a nibh.
+`,
+	}
+
+	for i, s := range sources {
+		r := wrapLine(s, 80)
+		if r != expected[i] {
+			t.Fatalf("expected:\n'%s'\ngot\n'%s'", expected[i], r)
+		}
+	}
+}

--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -1,0 +1,35 @@
+package lsp
+
+import (
+	"strings"
+
+	"github.com/onlyati/quadlet-lsp/internal/format"
+	"github.com/onlyati/quadlet-lsp/internal/syntax"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func Format(context *glsp.Context, params *protocol.DocumentFormattingParams) ([]protocol.TextEdit, error) {
+	uri := string(params.TextDocument.URI)
+	text := documents.Read(uri)
+	textLines := strings.Split(text, "\n")
+
+	// Only make formatting if no syntax error in the file
+	checker := syntax.NewSyntaxChecker(text, uri)
+	diags := checker.RunAll(config)
+	if len(diags) > 0 {
+		return nil, nil
+	}
+
+	newText := format.FormatDocument(text)
+
+	return []protocol.TextEdit{
+		{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 0},
+				End:   protocol.Position{Line: uint32(len(textLines)), Character: uint32(len(textLines[len(textLines)-1]))},
+			},
+			NewText: newText,
+		},
+	}, nil
+}

--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -26,7 +26,7 @@ import (
 const lsName = "quadlet"
 
 var (
-	version   = "0.5.0"
+	version   = "0.6.0rc1"
 	handler   protocol.Handler
 	config    *utils.QuadletConfig
 	documents = utils.NewDocuments()
@@ -134,6 +134,9 @@ func Start() {
 
 		// Handle commands that should be executed
 		WorkspaceExecuteCommand: ExecuteCommands,
+
+		// Handle format requests
+		TextDocumentFormatting: Format,
 	}
 
 	server := server.NewServer(&handler, lsName, false)

--- a/mise.toml
+++ b/mise.toml
@@ -11,5 +11,5 @@ description = "Run unit tests"
 run = "go test -race ./..."
 
 [tools]
-go = "1.24.4"
+go = "1.25.1"
 goreleaser = "2.12.1"


### PR DESCRIPTION
**Describe the problem why the PR is open**
Implement format function of language server

**Describe the solution**

Language server has feature to format the document. Format has the following
rules:

- Line width does not exceed the 80 character width. If a line is longer, then
  line is split by using `\` continuation sign.
- Each comment line is removed, except from the beginning of the file.
- Properties are grouped based on topics.
- Within the topics, settings are sorted based on alphabetical order.

Example formatted file:

```ini
# disable-qsr: qsr014 qsr013
#
# File name: gitea.container

[Unit]
Description=Gitea application
Wants=gitea-db.service

[Container]
# Base options
AutoUpdate=registry
Image=docker.io/gitea/gitea:latest-rootless
Pod=gitea.pod

# Storage options
Volume=/etc/localtime:/etc/localtime:ro
Volume=/etc/timezone:/etc/timezone:ro

# Environment options
Environment=GITEA__database__DB_TYPE=postgres
Environment=GITEA__database__HOST=127.0.0.1
Environment=GITEA__database__NAME=gitea
Environment=GITEA__database__USER=gitea

# Secret options
Secret=gitea-db-password,type=env,target=GITEA__database__PASSWD
Secret=gitea-smtp-password,type=env,target=GITEA__mailer__PASSWD

# Healthcheck options
HealthCmd=/bin/curlcurl -k --fail --connect-timeout 5 \
  https://127.0.0.1:3000/api/healthz
HealthRetries=10
HealthStartPeriod=15s
HealthTimeout=15s

# Other options
LogDriver=journald
UserNS=keep-id

[Service]
Restart=on-failure
RestartSec=5
StartLimitBurst=5

[Install]
WantedBy=default.target

```


**Checklist**
- [x] Fetaure implementation
- [x] Update documents
- [x] Write unit tests
