### PR TITLE
[repo] Downlevel go to compatible with Enterprise Linux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.24.4
 
       - name: Run Unit Tests
         run: go test ./... -v

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.24.4
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/onlyati/quadlet-lsp
 
-go 1.25.1
+go 1.24.4
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/stretchr/testify v1.11.1
-	github.com/tliron/commonlog v0.2.21
+	github.com/tliron/commonlog v0.2.20
 	github.com/tliron/glsp v0.2.2
 )
 
@@ -24,7 +24,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.6 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/sourcegraph/jsonrpc2 v0.2.1 // indirect
-	github.com/tliron/go-kutil v0.4.0 // indirect
+	github.com/tliron/kutil v0.3.27 // indirect
 	golang.org/x/crypto v0.42.0 // indirect
 	golang.org/x/net v0.44.0 // indirect
 	golang.org/x/sys v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,12 +32,12 @@ github.com/sourcegraph/jsonrpc2 v0.2.1 h1:2GtljixMQYUYCmIg7W9aF2dFmniq/mOr2T9tFR
 github.com/sourcegraph/jsonrpc2 v0.2.1/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/tliron/commonlog v0.2.21 h1:V1v+6opmzuOqDxxnxxM5RWtlHZmqZlDxkKeZGs6DpPg=
-github.com/tliron/commonlog v0.2.21/go.mod h1:W6XVoS/zo7mHXv2Kz8HKnBq+U34dFysJ2KUh2Aboibw=
+github.com/tliron/commonlog v0.2.20 h1:LjzkpM5tc9pB2UHVe4wnKN5ay5BxSFnDGCNhsKFqELo=
+github.com/tliron/commonlog v0.2.20/go.mod h1:v/8FkL/gzsX/1N48vK1luLa4xFasHfzYBONX7/4mD5Y=
 github.com/tliron/glsp v0.2.2 h1:IKPfwpE8Lu8yB6Dayta+IyRMAbTVunudeauEgjXBt+c=
 github.com/tliron/glsp v0.2.2/go.mod h1:GMVWDNeODxHzmDPvYbYTCs7yHVaEATfYtXiYJ9w1nBg=
-github.com/tliron/go-kutil v0.4.0 h1:5JwcBacgnqS3XyhwCWZKvq8ftlbVttNXnt+kfCH+Y2E=
-github.com/tliron/go-kutil v0.4.0/go.mod h1:hpHVq+CP1uci2M208UEjPiPwsRsz/QweGBnLB3CaQ24=
+github.com/tliron/kutil v0.3.27 h1:Wb0V5jdbTci6Let1tiGY741J/9FIynmV/pCsPDPsjcM=
+github.com/tliron/kutil v0.3.27/go.mod h1:AHeLNIFBSKBU39ELVHZdkw2f/ez2eKGAAGoxwBlhMi8=
 golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=
 golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
 golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=

--- a/mise.toml
+++ b/mise.toml
@@ -11,5 +11,5 @@ description = "Run unit tests"
 run = "go test -race ./..."
 
 [tools]
-go = "1.25.1"
+go = "1.24.4"
 goreleaser = "2.12.1"


### PR DESCRIPTION
**Describe the problem why the PR is open**
Dependabot upgraded the minimal Go version itself (https://github.com/onlyati/quadlet-lsp/pull/123), because of commonlog update. But it makes the building on EL10 more difficult.

**Describe the solution**
Downgrade commonlog and go version.

**Checklist**
- [ ] Fetaure implementation
- [ ] Update documents
- [ ] Write unit tests
