### PR TITLE
[fix] QSR011 did not cut '/tcp' and '/udp' for port checking

### DIFF
--- a/internal/syntax/qsr011.go
+++ b/internal/syntax/qsr011.go
@@ -70,6 +70,9 @@ func qsr011Action(q utils.QuadletLine, _ utils.PodmanVersion) []protocol.Diagnos
 	tmp := strings.Split(q.Value, ":")
 	usedPort := tmp[len(tmp)-1]
 
+	tmp = strings.Split(usedPort, "/")
+	usedPort = tmp[0]
+
 	if !slices.Contains(qsr011Ports, usedPort) {
 		if len(qsr011FailedCheck) == 0 {
 			return []protocol.Diagnostic{


### PR DESCRIPTION
**Describe the problem why the PR is open**
During `PublishPort` specification, it has been split onto two parts, separated by `:`, and the last elem was checked in image for port. But by syntax this line can end with `/udp` or `/tcp`.

**Describe the solution**
Second element is also split at `/` charcater.

**Checklist**
- [X] Fetaure implementation
- [X] Update documents
- [X] Write unit tests
