### PR TITLE
Add new features of Podman v5.7.0 for container, pod and build

### DIFF
--- a/internal/data/properties.go
+++ b/internal/data/properties.go
@@ -1947,6 +1947,7 @@ $0
 					"",
 					"This is equivalent to the `--ignorefile` option of `podman build`.",
 				},
+				MinVersion: utils.BuildPodmanVersion(5, 7, 0),
 			},
 			{
 				Label: "ImageTag",


### PR DESCRIPTION
**Describe the problem why the PR is open**

- Quadlet .container files now support a new key, HttpProxy, to disable the automatic forwarding of HTTP proxy options from the host into the container
- Quadlet .pod files now support a new key, StopTimeout, to configure the stop timeout for the pod
- Quadlet .build files now support two new keys, BuildArg and IgnoreFile, to specify build arguments and an ignore file

**Describe the solution**
Properties file has been updated.

**Checklist**
- [x] Feature implementation
- [x] Update documents
- [x] Write unit tests
