### PR TITLE
feat: Add support for finding adjacent pod files (QSR-017)

### DIFF
--- a/internal/syntax/qsr017_test.go
+++ b/internal/syntax/qsr017_test.go
@@ -3,6 +3,8 @@ package syntax
 import (
 	"os"
 	"testing"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
 )
 
 func TestQSR017_Valid(t *testing.T) {
@@ -57,5 +59,38 @@ func TestQSR017_Invalid(t *testing.T) {
 		if diags[0].Message != "Pod file does not exists: test.pod" {
 			t.Fatalf("Unexpected message: '%s' at %s", diags[0].Message, s.uri)
 		}
+	}
+}
+
+// TestQSR017_ValidAdjacentFile tests that pod files are found adjacent to the container file,
+// even when the working directory is different (e.g., the workspace root).
+func TestQSR017_ValidAdjacentFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Chdir(tmpDir)
+
+	// Create a subdirectory for the container and pod files
+	subDir := createTempDir(t, tmpDir, "subdir")
+
+	// Create the pod file in the subdirectory
+	createTempFile(
+		t,
+		subDir,
+		"test.pod",
+		"[Pod]",
+	)
+
+	// Create the container file in the subdirectory that references the pod file
+	s := NewSyntaxChecker(
+		"[Container]\nPod=test.pod",
+		"file://"+subDir+"/test1.container",
+	)
+	s.config = &utils.QuadletConfig{
+		WorkspaceRoot: tmpDir,
+	}
+
+	diags := qsr017(s)
+
+	if len(diags) != 0 {
+		t.Fatalf("Expected 0 diagnostics, got %d at %s", len(diags), s.uri)
 	}
 }


### PR DESCRIPTION
 Fixes QSR-017 validation to correctly locate pod files adjacent to the container file, rather than searching relative to the current working directory.

## Problem
Previously, QSR-017 would only check for pod files in the current working directory (`./${podName}`). This caused false positives when:
  - The workspace root differs from the file location
  - Container files are in subdirectories
  - IDE/LSP changes the working directory

## Solution
  - Extract the directory path from the container file's URI
  - Check for pod files adjacent to the container file using proper path resolution
  - Utilize the workspace root from config when available

## Changes
  - **qsr017.go**: Refactored to use `path.Join(fileDir, podName)` for adjacent file lookup
  - **qsr017_test.go**: Added `TestQSR017_ValidAdjacentFile` to verify behavior when working directory differs from file location
  - Cleaned up error handling (removed unnecessary log statement)

## Example
  Before this fix:
  workspace/
    └── containers/
        ├── app.container  # Pod=app.pod
        └── app.pod        # ❌ Not found if working directory is workspace/

  After this fix:
  workspace/
    └── containers/
        ├── app.container  # Pod=app.pod
        └── app.pod        # ✅ Found correctly regardless of working directory

  ## Testing

  ```bash
  mise exec -- go test -v ./internal/syntax -run TestQSR017
  All tests pass ✅
  ```