### PR TITLE
[fix] wrong document for disable QSR in quadletrc

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -103,7 +103,7 @@ Description=...
 If `.quadletrc.json` file exists in the current working directory, then some
 settings can be override.
 
-- `disabled`: A string array, if any syntax checker source can be found here
+- `disable`: A string array, if any syntax checker source can be found here
   that is ignored.
 - `podmanVersion`: Podman version can be specified. It can be useful if you want
   to make Quadlets to another system where older Podman running than on your
@@ -115,7 +115,7 @@ Example for file:
 
 ```json
 {
-  "disabled": ["qsr013", "qsr004"],
+  "disable": ["qsr013", "qsr004"],
   "podmanVersion": "5.4.0"
 }
 ```

--- a/pkg/parser/parse_quadlet_dir.go
+++ b/pkg/parser/parse_quadlet_dir.go
@@ -18,7 +18,7 @@ func ParseQuadletDir(rootDir string) (QuadletDirectory, error) {
 	content, err := os.ReadFile(path.Join(rootDir, ".quadletrc.json"))
 	if err == nil {
 		disableRules := struct {
-			Disabled []string `json:"disabled"`
+			Disabled []string `json:"disable"`
 		}{}
 		_ = json.Unmarshal(content, &disableRules)
 		qd.DisabledQSR = disableRules.Disabled

--- a/pkg/parser/parse_quadlet_dir_test.go
+++ b/pkg/parser/parse_quadlet_dir_test.go
@@ -32,7 +32,7 @@ Image=docker.io/library/debian
 		t,
 		tmpDir,
 		".quadletrc.json",
-		`{ "disabled": ["qsr001", "qsr002"] }`,
+		`{ "disable": ["qsr001", "qsr002"] }`,
 	)
 
 	expected := parser.QuadletDirectory{


### PR DESCRIPTION
**Describe the problem why the PR is open**
https://github.com/onlyati/quadlet-lsp/issues/158

**Describe the solution**
It was a document mistake, it should be `disable` in the `quadletrc.json` instead of `disabled`.

**Checklist**
- [x] Feature implementation
- [x] Update documents
- [x] Write unit tests
