### PR TITLE
[fix] Update qsr015.go to fix typo on 'rshared' flag

### DIFF
--- a/internal/syntax/qsr015.go
+++ b/internal/syntax/qsr015.go
@@ -22,7 +22,7 @@ var qsr015ValidFlags = []string{
 	"exec", "noexec",
 	"suid", "nosuid",
 	"bind", "rbind",
-	"shared", "shared",
+	"shared", "rshared",
 	"slave", "rslave",
 	"private", "rprivate",
 	"unbindable", "runbindable",


### PR DESCRIPTION
**Describe the problem why the PR is open**
When using the `rshared` flag in a volume mount, the LSP is returning the following error, even though it's a valid value:
```
Invalid format of Volume specification: 'rshared' flag is unknown (quadlet-lsp.qsr015)
``` 

**Describe the solution**
I figured it was just a small typo on the syntax definition file, in which the second `shared` was missing its `r`.

**Checklist**
- [ ] Feature implementation
- [ ] Update documents
- [ ] Write unit tests
