### PR TITLE
Add warning if not directory is open

### DIFF
--- a/internal/lsp/lsp.go
+++ b/internal/lsp/lsp.go
@@ -4,6 +4,7 @@
 package lsp
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -124,6 +125,15 @@ func Start() {
 }
 
 func initialize(context *glsp.Context, params *protocol.InitializeParams) (any, error) {
+	// If no RootURI, it means no directory open, do not initialize lsp
+	if params.RootURI == nil {
+		context.Notify(protocol.ServerWindowShowMessage, protocol.ShowMessageParams{
+			Type:    protocol.MessageTypeWarning,
+			Message: "Open directory to be able to use quadlet-lsp",
+		})
+		return nil, errors.New("open directory to use quadlet-lsp")
+	}
+
 	// Read and parse configuration
 	workspaceDir := *params.RootURI
 


### PR DESCRIPTION
**Describe the problem why the PR is open**
If a single file was open with VS Code, language server got crashed.

**Describe the solution**
Reason of the crash, that the editor does not pass the root URI. Because language server has several traversal function (e.g.: go definition/reference, some syntax/completion looking for other files), language server simply gives a warning that a directory should be open instead.

**Checklist**
- [ ] Feature implementation
- [ ] Update documents
- [ ] Write unit tests
