### PR TITLE
[fix] Provide completion for property even with '=' sign

### DIFF
--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -67,7 +67,7 @@ func (s Completion) RunCompletion(config *utils.QuadletConfig) []protocol.Comple
 	}
 
 	// There is a '=' in the line, so check for property's value
-	if isItPropertyCompletion(s.text[s.line], s.char) {
+	if isItPropertyCompletion(s) {
 		return listPropertyCompletions(s)
 	}
 
@@ -77,6 +77,7 @@ func (s Completion) RunCompletion(config *utils.QuadletConfig) []protocol.Comple
 	}
 
 	// If this point is reached, then user probably type something
-	// at the beginning of a file, let's suggest some property
+	// at the beginning of a file, let's suggest some property.
+	// Or typing before the '=' sign in a line
 	return listNewProperties(s)
 }

--- a/internal/completion/new_property.go
+++ b/internal/completion/new_property.go
@@ -10,6 +10,15 @@ import (
 func listNewProperties(s Completion) []protocol.CompletionItem {
 	var completionItems []protocol.CompletionItem
 
+	// If this is a continuation line, then it is not a new property
+	if s.line > 0 {
+		t := strings.TrimSpace(s.text[s.line-1])
+		if t[len(t)-1] == '\\' {
+			return completionItems
+		}
+	}
+
+	// Normal processing
 	s.config.Mu.RLock()
 	podVer := s.config.Podman
 	s.config.Mu.RUnlock()

--- a/internal/completion/new_property_test.go
+++ b/internal/completion/new_property_test.go
@@ -1,0 +1,55 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/onlyati/quadlet-lsp/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ListNewProperties(t *testing.T) {
+	cases := []Completion{
+		{
+			line: 0,
+			text: []string{"H"},
+			char: 1,
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 6, 0),
+			},
+			section: "Container",
+		},
+		{
+			line: 0,
+			text: []string{"Foo=bar", "H"},
+			char: 1,
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 6, 0),
+			},
+			section: "Container",
+		},
+	}
+
+	for _, s := range cases {
+		result := listNewProperties(s)
+		assert.Greater(t, len(result), 0)
+	}
+}
+
+func Test_ListNewPropertiesWithCont(t *testing.T) {
+	cases := []Completion{
+		{
+			line: 1,
+			text: []string{"Foo=bar \\", "H"},
+			char: 1,
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 6, 0),
+			},
+			section: "Container",
+		},
+	}
+
+	for _, s := range cases {
+		result := listNewProperties(s)
+		assert.Equal(t, 0, len(result))
+	}
+}

--- a/internal/completion/property.go
+++ b/internal/completion/property.go
@@ -7,9 +7,10 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-func isItPropertyCompletion(line string, pos protocol.UInteger) bool {
-	idxEquale := uint32(strings.Index(line, "="))
-	return pos > idxEquale
+func isItPropertyCompletion(s Completion) bool {
+	// Check we are after '=' or after
+	idxEquale := uint32(strings.Index(s.text[s.line], "="))
+	return s.char > idxEquale
 }
 
 func listPropertyCompletions(s Completion) []protocol.CompletionItem {

--- a/internal/completion/property_test.go
+++ b/internal/completion/property_test.go
@@ -1,0 +1,27 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IsItPropertyCompletion(t *testing.T) {
+	cases := []Completion{
+		{
+			line: 0,
+			text: []string{"Foo="},
+			char: 4,
+		},
+		{
+			line: 0,
+			text: []string{"Foo=bar"},
+			char: 6,
+		},
+	}
+
+	for _, s := range cases {
+		result := isItPropertyCompletion(s)
+		assert.True(t, result, "test should have been valid")
+	}
+}


### PR DESCRIPTION
**Describe the problem why the PR is open**
See https://github.com/onlyati/quadlet-lsp/issues/163

**Describe the solution**
Checking the cursor position and compare it with equal.

**Checklist**
- [x] Feature implementation
- [ ] Update documents
- [x] Write unit tests
