### PR TITLE
[fix] Provide completion for port in dropins

### DIFF
--- a/internal/completion/property_image_test.go
+++ b/internal/completion/property_image_test.go
@@ -24,6 +24,14 @@ func createTempFile(t *testing.T, dir, name, content string) string {
 	return path
 }
 
+func createTempDir(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.Mkdir(path, 0o755)
+	assert.NoError(t, err)
+	return path
+}
+
 func TestPropertyImage_Valid(t *testing.T) {
 	tmpDir := t.TempDir()
 	_ = os.Chdir(tmpDir)

--- a/internal/completion/property_port.go
+++ b/internal/completion/property_port.go
@@ -14,7 +14,7 @@ func propertyListPorts(s Completion) []protocol.CompletionItem {
 	colons := strings.Count(s.text[s.line], ":")
 	tmp := strings.Split(s.text[s.line], ":")
 
-	// We need complation in two cases:
+	// We need completion in two cases:
 	// ExposedPorts=127.0.0.1:420:69
 	// ExposedPorts=420:69
 	if colons == 0 {


### PR DESCRIPTION
**Describe the problem why the PR is open**
https://github.com/onlyati/quadlet-lsp/issues/129

**Describe the solution**
If the file in buffer is a *.conf file, then get the owner container and start search in that (indirect way, it also search in dropins too).

**Checklist**
- [x] Feature implementation
- [ ] Update documents
- [x] Write unit tests
