### PR TITLE
[fix] Completion crashes if previous line empty

### DIFF
--- a/internal/completion/new_property.go
+++ b/internal/completion/new_property.go
@@ -13,7 +13,7 @@ func listNewProperties(s Completion) []protocol.CompletionItem {
 	// If this is a continuation line, then it is not a new property
 	if s.line > 0 {
 		t := strings.TrimSpace(s.text[s.line-1])
-		if t[len(t)-1] == '\\' {
+		if strings.HasSuffix(t, "\\") {
 			return completionItems
 		}
 	}

--- a/internal/completion/new_property_test.go
+++ b/internal/completion/new_property_test.go
@@ -27,6 +27,15 @@ func Test_ListNewProperties(t *testing.T) {
 			},
 			section: "Container",
 		},
+		{
+			line: 1,
+			text: []string{"", "H"},
+			char: 1,
+			config: &utils.QuadletConfig{
+				Podman: utils.BuildPodmanVersion(5, 6, 0),
+			},
+			section: "Container",
+		},
 	}
 
 	for _, s := range cases {


### PR DESCRIPTION
**Describe the problem why the PR is open**
Sometimes the language server has crash
```
[ERROR][2026-01-20 21:52:20] ...nt_nvimfOGCCj/usr/share/nvim/runtime/lua/vim/lsp/log.lua:151    "rpc"   "quadlet-lsp"   "stderr"        "panic: runtime error: index out of range [-1]\n\ngoroutine 8 [running]:\n"
[ERROR][2026-01-20 21:52:20] ...nt_nvimfOGCCj/usr/share/nvim/runtime/lua/vim/lsp/log.lua:151    "rpc"   "quadlet-lsp"   "stderr"        "github.com/onlyati/quadlet-lsp/internal/completion.listNewProperties({{0xc0004e8a88, 0x31, 0x31}, 0xd, 0x1, {0xc00053c400, 0x33}, {0x766840, 0x9835
c0}, 0xc00003d780, ...})\n\t/home/runner/work/quadlet-lsp/quadlet-lsp/internal/completion/new_property.go:16 +0x405\ngithub.com/onlyati/quadlet-lsp/internal/completion.Completion.RunCompletion({{0xc0004e8a88, 0x31, 0x31}, 0xd, 0x1, {0xc00053c400, 0x33}, {0x766840, 0x9835c0}, 0xc00003
d780, ...}, ...)\n\t/home/runner/work/quadlet-lsp/quadlet-lsp/internal/completion/completion.go:82 +0x2a5\ngithub.com/onlyati/quadlet-lsp/internal/lsp.textCompletion(0xc000500090?, 0xc0001cf860)\n\t/home/runner/work/quadlet-lsp/quadlet-lsp/internal/lsp/completion.go:27 +0x19f\ngithub
.com/tliron/glsp/protocol_3_16.(*Handler).Handle(0x9632c0, 0xc00053ab80)\n\t/home/runner/work/quadlet-lsp/quadlet-lsp/vendor/github.com/tliron/glsp/protocol_3_16/handler.go:372 +0x163f\ngithub.com/tliron/glsp/server.(*Server).handle(0xc0000905a0, {0x7685c8, 0x9835c0}, 0xc000192360, 0
xc0003c7320)\n\t/home/runner/work/quadlet-lsp/quadlet-lsp/vendor/github.com/tliron/glsp/server/handle.go:46 +0x276"
[ERROR][2026-01-20 21:52:20] ...nt_nvimfOGCCj/usr/share/nvim/runtime/lua/vim/lsp/log.lua:151    "rpc"   "quadlet-lsp"   "stderr"        "\ngithub.com/sourcegraph/jsonrpc2.(*HandlerWithErrorConfigurer).Handle(0xc0000136e0, {0x7685c8, 0x9835c0}, 0xc000192360, 0xc0003c7320)\n\t/home/run
ner/work/quadlet-lsp/quadlet-lsp/vendor/github.com/sourcegraph/jsonrpc2/handler_with_error.go:21 +0x4f\ngithub.com/sourcegraph/jsonrpc2.(*Conn).readMessages(0xc000192360, {0x7685c8, 0x9835c0})\n\t/home/runner/work/quadlet-lsp/quadlet-lsp/vendor/github.com/sourcegraph/jsonrpc2/conn.go
:205 +0x276\ncreated by github.com/sourcegraph/jsonrpc2.NewConn in goroutine 1\n\t/home/runner/work/quadlet-lsp/quadlet-lsp/vendor/github.com/sourcegraph/jsonrpc2/conn.go:62 +0x1e6\n"
```

**Describe the solution**
It happened when the previous line length was zero, so the `len(t)-1` result is -1.

**Checklist**
- [x] Feature implementation
- [ ] Update documents
- [x] Write unit tests
