### PR TITLE
[feature] Add new `AppArmor` keyword from Podman 5.8.0

### DIFF
--- a/internal/data/properties.go
+++ b/internal/data/properties.go
@@ -385,6 +385,14 @@ $0
 				MultipleAdd: true,
 			},
 			{
+				Label: "AppArmor",
+				Hover: []string{
+					"Sets the apparmor confinement profile for the container. A value of `unconfined` turns off apparmor confinement.",
+				},
+				FormatGroup: FormatGroupBase,
+				MinVersion:  utils.BuildPodmanVersion(5, 8, 0),
+			},
+			{
 				Label: "AutoUpdate",
 				Hover: []string{
 					"Indicates whether the container will be auto-updated ([podman-auto-update(1)](https://docs.podman.io/en/latest/markdown/podman-auto-update.1.html)). The following values are supported:",


### PR DESCRIPTION
**Describe the problem why the PR is open**
In a 5.8.0 release candidate has a new keyword on container files, see more: https://github.com/containers/podman/releases/tag/v5.8.0-rc1

**Describe the solution**
Add for the properties.

**Checklist**
- [x] Feature implementation
- [ ] Update documents
- [ ] Write unit tests
