### PR TITLE
update flake.nix for go 1.25.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762977756,
-        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       pkgs = nixpkgsFor.${system};
     in {
       default =
-        pkgs.buildGo124Module rec
+        pkgs.buildGo125Module rec
         {
           pname = "quadlet-lsp";
           version = "0.7.2";


### PR DESCRIPTION
Also includes updated lockfile

When the go version is updated, the flake.nix must be updated to correspond, or else the build fails with a version mismatch.


Switch to `buildGo125Module` and run `nix flake update`. I don't think the hash needs to be changed at this time, but may be considered.